### PR TITLE
chore: configure linter to prefer const over let/var

### DIFF
--- a/src/atem.ts
+++ b/src/atem.ts
@@ -51,8 +51,8 @@ export class Atem extends EventEmitter {
 	}
 
 	sendCommand (command: AbstractCommand): Promise<any> {
-		let nextPacketId = this.socket.nextPacketId
-		let promise = new Promise((resolve, reject) => {
+		const nextPacketId = this.socket.nextPacketId
+		const promise = new Promise((resolve, reject) => {
 			command.resolve = resolve
 			command.reject = reject
 		})
@@ -62,123 +62,123 @@ export class Atem extends EventEmitter {
 	}
 
 	changeProgramInput (input: number, me = 0) {
-		let command = new Commands.ProgramInputCommand()
+		const command = new Commands.ProgramInputCommand()
 		command.mixEffect = me
 		command.updateProps({source: input})
 		return this.sendCommand(command)
 	}
 
 	changePreviewInput (input: number, me = 0) {
-		let command = new Commands.PreviewInputCommand()
+		const command = new Commands.PreviewInputCommand()
 		command.mixEffect = me
 		command.updateProps({source: input})
 		return this.sendCommand(command)
 	}
 
 	cut (me = 0) {
-		let command = new Commands.CutCommand()
+		const command = new Commands.CutCommand()
 		command.mixEffect = me
 		return this.sendCommand(command)
 	}
 
 	autoTransition (me = 0) {
-		let command = new Commands.AutoTransitionCommand()
+		const command = new Commands.AutoTransitionCommand()
 		command.mixEffect = me
 		return this.sendCommand(command)
 	}
 
 	autoDownstreamKey (key = 0) {
-		let command = new Commands.DownstreamKeyAutoCommand()
+		const command = new Commands.DownstreamKeyAutoCommand()
 		command.downstreamKeyId = key
 		return this.sendCommand(command)
 	}
 
 	setDipTransitionSettings (newProps: Partial<DipTransitionSettings>, me = 0) {
-		let command = new Commands.TransitionDipCommand()
+		const command = new Commands.TransitionDipCommand()
 		command.mixEffect = me
 		command.updateProps(newProps)
 		return this.sendCommand(command)
 	}
 
 	setDVETransitionSettings (newProps: Partial<DVETransitionSettings>, me = 1) {
-		let command = new Commands.TransitionDVECommand()
+		const command = new Commands.TransitionDVECommand()
 		command.mixEffect = me
 		command.updateProps(newProps)
 		return this.sendCommand(command)
 	}
 
 	setMixTransitionSettings (newProps: Partial<MixTransitionSettings>, me = 0) {
-		let command = new Commands.TransitionMixCommand()
+		const command = new Commands.TransitionMixCommand()
 		command.mixEffect = me
 		command.updateProps(newProps)
 		return this.sendCommand(command)
 	}
 
 	setTransitionPosition (position: number, me = 0) {
-		let command = new Commands.TransitionPositionCommand()
+		const command = new Commands.TransitionPositionCommand()
 		command.mixEffect = me
 		command.updateProps({handlePosition: position})
 		return this.sendCommand(command)
 	}
 
 	previewTransition (on: boolean, me = 0) {
-		let command = new Commands.PreviewTransitionCommand()
+		const command = new Commands.PreviewTransitionCommand()
 		command.mixEffect = me
 		command.updateProps({preview: on})
 		return this.sendCommand(command)
 	}
 
 	setTransitionStyle (newProps: Partial<TransitionProperties>, me = 0) {
-		let command = new Commands.TransitionPropertiesCommand()
+		const command = new Commands.TransitionPropertiesCommand()
 		command.mixEffect = me
 		command.updateProps(newProps)
 		return this.sendCommand(command)
 	}
 
 	setStingerTransitionSettings (newProps: Partial<StingerTransitionSettings>, me = 0) {
-		let command = new Commands.TransitionStingerCommand()
+		const command = new Commands.TransitionStingerCommand()
 		command.mixEffect = me
 		command.updateProps(newProps)
 		return this.sendCommand(command)
 	}
 
 	setWipeTransitionSettings (newProps: Partial<WipeTransitionSettings>, me = 0) {
-		let command = new Commands.TransitionWipeCommand()
+		const command = new Commands.TransitionWipeCommand()
 		command.mixEffect = me
 		command.updateProps(newProps)
 		return this.sendCommand(command)
 	}
 
 	setAuxSource (source: number, bus = 0) {
-		let command = new Commands.AuxSourceCommand()
+		const command = new Commands.AuxSourceCommand()
 		command.auxBus = bus
 		command.updateProps({source})
 		return this.sendCommand(command)
 	}
 
 	setDownstreamKeyTie (tie: boolean, key = 0) {
-		let command = new Commands.DownstreamKeyTieCommand()
+		const command = new Commands.DownstreamKeyTieCommand()
 		command.downstreamKeyId = key
 		command.updateProps({tie})
 		return this.sendCommand(command)
 	}
 
 	setDownstreamKeyOnAir (onAir: boolean, key = 0) {
-		let command = new Commands.DownstreamKeyOnAirCommand()
+		const command = new Commands.DownstreamKeyOnAirCommand()
 		command.downstreamKeyId = key
 		command.updateProps({onAir})
 		return this.sendCommand(command)
 	}
 
 	macroRun (index = 0) {
-		let command = new Commands.MacroActionCommand()
+		const command = new Commands.MacroActionCommand()
 		command.index = index
 		command.updateProps({action: MacroAction.Run})
 		return this.sendCommand(command)
 	}
 
 	setMediaPlayerSettings (newProps: Partial<MediaPlayer>, player = 0) {
-		let command = new Commands.MediaPlayerStatusCommand()
+		const command = new Commands.MediaPlayerStatusCommand()
 		command.mediaPlayerId = player
 		command.updateProps(newProps)
 		return this.sendCommand(command)

--- a/src/commands/AbstractCommand.ts
+++ b/src/commands/AbstractCommand.ts
@@ -26,7 +26,7 @@ export default abstract class AbstractCommand {
 		}
 
 		if (this.MaskFlags) {
-			for (let key in newProps) {
+			for (const key in newProps) {
 				if (key in this.MaskFlags) {
 					this.flag = this.flag | this.MaskFlags[key]
 				}

--- a/src/commands/AuxSourceCommand.ts
+++ b/src/commands/AuxSourceCommand.ts
@@ -17,7 +17,7 @@ export class AuxSourceCommand extends AbstractCommand {
 	}
 
 	serialize () {
-		let rawCommand = 'CAuS'
+		const rawCommand = 'CAuS'
 		return new Buffer([
 			...Buffer.from(rawCommand),
 			0x01,

--- a/src/commands/DeviceProfile/productIdentifierCommand.ts
+++ b/src/commands/DeviceProfile/productIdentifierCommand.ts
@@ -17,7 +17,7 @@ export class ProductIdentifierCommand extends AbstractCommand {
 	}
 
 	serialize () {
-		let rawName = Buffer.from(this.properties.deviceName)
+		const rawName = Buffer.from(this.properties.deviceName)
 		// https://github.com/LibAtem/LibAtem/blob/master/LibAtem/Commands/DeviceProfile/ProductIdentifierCommand.cs#L12
 		return Buffer.from([
 			...Buffer.from(rawName),

--- a/src/commands/DownstreamKey/DownstreamKeyAutoCommand.ts
+++ b/src/commands/DownstreamKey/DownstreamKeyAutoCommand.ts
@@ -11,7 +11,7 @@ export class DownstreamKeyAutoCommand extends AbstractCommand {
 	}
 
 	serialize () {
-		let rawCommand = 'DDsA'
+		const rawCommand = 'DDsA'
 		return new Buffer([
 			...Buffer.from(rawCommand),
 			this.downstreamKeyId,

--- a/src/commands/DownstreamKey/DownstreamKeyOnAirCommand.ts
+++ b/src/commands/DownstreamKey/DownstreamKeyOnAirCommand.ts
@@ -13,7 +13,7 @@ export class DownstreamKeyOnAirCommand extends AbstractCommand {
 	}
 
 	serialize () {
-		let rawCommand = 'CDsL'
+		const rawCommand = 'CDsL'
 		return new Buffer([
 			...Buffer.from(rawCommand),
 			this.downstreamKeyId,

--- a/src/commands/DownstreamKey/DownstreamKeyTieCommand.ts
+++ b/src/commands/DownstreamKey/DownstreamKeyTieCommand.ts
@@ -13,7 +13,7 @@ export class DownstreamKeyTieCommand extends AbstractCommand {
 	}
 
 	serialize () {
-		let rawCommand = 'CDsT'
+		const rawCommand = 'CDsT'
 		return new Buffer([
 			...Buffer.from(rawCommand),
 			this.downstreamKeyId,

--- a/src/commands/Macro/MacroActionCommand.ts
+++ b/src/commands/Macro/MacroActionCommand.ts
@@ -14,8 +14,8 @@ export class MacroActionCommand extends AbstractCommand {
 	}
 
 	serialize () {
-		let rawCommand = 'MAct'
-		let buffer = new Buffer([...Buffer.from(rawCommand), 0x00, 0x00, this.properties.action, 0x00])
+		const rawCommand = 'MAct'
+		const buffer = new Buffer([...Buffer.from(rawCommand), 0x00, 0x00, this.properties.action, 0x00])
 		switch (this.properties.action) {
 			case MacroAction.Run :
 			case MacroAction.Delete :

--- a/src/commands/Media/MediaPlayerStatusCommand.ts
+++ b/src/commands/Media/MediaPlayerStatusCommand.ts
@@ -29,7 +29,7 @@ export class MediaPlayerStatusCommand extends AbstractCommand {
 	}
 
 	serialize () {
-		let rawCommand = 'SCPS'
+		const rawCommand = 'SCPS'
 		return new Buffer([
 			...Buffer.from(rawCommand),
 			this.flag,

--- a/src/commands/MixEffects/AutoTransitionCommand.ts
+++ b/src/commands/MixEffects/AutoTransitionCommand.ts
@@ -11,7 +11,7 @@ export class AutoTransitionCommand extends AbstractCommand {
 	}
 
 	serialize () {
-		let rawCommand = 'DAut'
+		const rawCommand = 'DAut'
 		return new Buffer([...Buffer.from(rawCommand), this.mixEffect, 0x00, 0x00, 0x00])
 	}
 

--- a/src/commands/MixEffects/CutCommand.ts
+++ b/src/commands/MixEffects/CutCommand.ts
@@ -11,7 +11,7 @@ export class CutCommand extends AbstractCommand {
 	}
 
 	serialize () {
-		let rawCommand = 'DCut'
+		const rawCommand = 'DCut'
 		return new Buffer([...Buffer.from(rawCommand), this.mixEffect, 0xef, 0xbf, 0x5f])
 	}
 

--- a/src/commands/MixEffects/PreviewInputCommand.ts
+++ b/src/commands/MixEffects/PreviewInputCommand.ts
@@ -17,7 +17,7 @@ export class PreviewInputCommand extends AbstractCommand {
 	}
 
 	serialize () {
-		let rawCommand = 'CPvI'
+		const rawCommand = 'CPvI'
 		return new Buffer([
 			...Buffer.from(rawCommand),
 			this.mixEffect,
@@ -28,7 +28,7 @@ export class PreviewInputCommand extends AbstractCommand {
 	}
 
 	applyToState (state: AtemState) {
-		let mixEffect = state.video.getMe(this.mixEffect)
+		const mixEffect = state.video.getMe(this.mixEffect)
 		mixEffect.programInput = this.properties.source
 	}
 }

--- a/src/commands/MixEffects/ProgramInputCommand.ts
+++ b/src/commands/MixEffects/ProgramInputCommand.ts
@@ -17,7 +17,7 @@ export class ProgramInputCommand extends AbstractCommand {
 	}
 
 	serialize () {
-		let rawCommand = 'CPgI'
+		const rawCommand = 'CPgI'
 		return new Buffer([
 			...Buffer.from(rawCommand),
 			this.mixEffect,
@@ -28,7 +28,7 @@ export class ProgramInputCommand extends AbstractCommand {
 	}
 
 	applyToState (state: AtemState) {
-		let mixEffect = state.video.getMe(this.mixEffect)
+		const mixEffect = state.video.getMe(this.mixEffect)
 		mixEffect.programInput = this.properties.source
 	}
 }

--- a/src/commands/MixEffects/Transition/TransitionDVECommand.ts
+++ b/src/commands/MixEffects/Transition/TransitionDVECommand.ts
@@ -46,8 +46,8 @@ export class TransitionDVECommand extends AbstractCommand {
 	}
 
 	serialize () {
-		let rawCommand = 'CTDv'
-		let buffer = new Buffer(24)
+		const rawCommand = 'CTDv'
+		const buffer = new Buffer(24)
 		buffer.fill(0)
 		Buffer.from(rawCommand).copy(buffer, 0)
 
@@ -73,7 +73,7 @@ export class TransitionDVECommand extends AbstractCommand {
 	}
 
 	applyToState (state: AtemState) {
-		let mixEffect = state.video.getMe(this.mixEffect)
+		const mixEffect = state.video.getMe(this.mixEffect)
 		mixEffect.transitionSettings.DVE = {
 			...this.properties
 		}

--- a/src/commands/MixEffects/Transition/TransitionDipCommand.ts
+++ b/src/commands/MixEffects/Transition/TransitionDipCommand.ts
@@ -25,7 +25,7 @@ export class TransitionDipCommand extends AbstractCommand {
 	}
 
 	serialize () {
-		let rawCommand = 'CTDp'
+		const rawCommand = 'CTDp'
 		return new Buffer([
 			...Buffer.from(rawCommand),
 			this.flag,
@@ -40,7 +40,7 @@ export class TransitionDipCommand extends AbstractCommand {
 	}
 
 	applyToState (state: AtemState) {
-		let mixEffect = state.video.getMe(this.mixEffect)
+		const mixEffect = state.video.getMe(this.mixEffect)
 		mixEffect.transitionSettings.dip = {
 			...this.properties
 		}

--- a/src/commands/MixEffects/Transition/TransitionMixCommand.ts
+++ b/src/commands/MixEffects/Transition/TransitionMixCommand.ts
@@ -20,7 +20,7 @@ export class TransitionMixCommand extends AbstractCommand {
 	}
 
 	serialize () {
-		let rawCommand = 'CTMx'
+		const rawCommand = 'CTMx'
 		return new Buffer([
 			...Buffer.from(rawCommand),
 			this.mixEffect,
@@ -30,7 +30,7 @@ export class TransitionMixCommand extends AbstractCommand {
 	}
 
 	applyToState (state: AtemState) {
-		let mixEffect = state.video.getMe(this.mixEffect)
+		const mixEffect = state.video.getMe(this.mixEffect)
 		mixEffect.transitionSettings.mix = {
 			...this.properties
 		}

--- a/src/commands/MixEffects/Transition/TransitionPositionCommand.ts
+++ b/src/commands/MixEffects/Transition/TransitionPositionCommand.ts
@@ -21,7 +21,7 @@ export class TransitionPositionCommand extends AbstractCommand {
 	}
 
 	serialize () {
-		let rawCommand = 'CTPs'
+		const rawCommand = 'CTPs'
 		return new Buffer([
 			...Buffer.from(rawCommand),
 			this.mixEffect,
@@ -32,7 +32,7 @@ export class TransitionPositionCommand extends AbstractCommand {
 	}
 
 	applyToState (state: AtemState) {
-		let mixEffect = state.video.getMe(this.mixEffect)
+		const mixEffect = state.video.getMe(this.mixEffect)
 		mixEffect.transitionFramesLeft = this.properties.remainingFrames
 		mixEffect.transitionPosition = this.properties.handlePosition
 		mixEffect.inTransition = this.properties.inTransition

--- a/src/commands/MixEffects/Transition/TransitionPreviewCommand.ts
+++ b/src/commands/MixEffects/Transition/TransitionPreviewCommand.ts
@@ -17,7 +17,7 @@ export class PreviewTransitionCommand extends AbstractCommand {
 	}
 
 	serialize () {
-		let rawCommand = 'CTPr'
+		const rawCommand = 'CTPr'
 		return new Buffer([
 			...Buffer.from(rawCommand),
 			this.mixEffect,
@@ -27,7 +27,7 @@ export class PreviewTransitionCommand extends AbstractCommand {
 	}
 
 	applyToState (state: AtemState) {
-		let mixEffect = state.video.getMe(this.mixEffect)
+		const mixEffect = state.video.getMe(this.mixEffect)
 		mixEffect.transitionPreview = this.properties.preview
 	}
 }

--- a/src/commands/MixEffects/Transition/TransitionPropertiesCommand.ts
+++ b/src/commands/MixEffects/Transition/TransitionPropertiesCommand.ts
@@ -27,8 +27,8 @@ export class TransitionPropertiesCommand extends AbstractCommand {
 	}
 
 	serialize () {
-		let rawCommand = 'CTTp'
-		let buffer = new Buffer(8)
+		const rawCommand = 'CTTp'
+		const buffer = new Buffer(8)
 		buffer.fill(0)
 		Buffer.from(rawCommand).copy(buffer, 0)
 
@@ -42,7 +42,7 @@ export class TransitionPropertiesCommand extends AbstractCommand {
 	}
 
 	applyToState (state: AtemState) {
-		let mixEffect = state.video.getMe(this.mixEffect)
+		const mixEffect = state.video.getMe(this.mixEffect)
 		mixEffect.transitionProperties = {
 			...this.properties
 		}

--- a/src/commands/MixEffects/Transition/TransitionStingerCommand.ts
+++ b/src/commands/MixEffects/Transition/TransitionStingerCommand.ts
@@ -41,8 +41,8 @@ export class TransitionStingerCommand extends AbstractCommand {
 	}
 
 	serialize () {
-		let rawCommand = 'CTSt'
-		let buffer = new Buffer(24)
+		const rawCommand = 'CTSt'
+		const buffer = new Buffer(24)
 		buffer.fill(0)
 		Buffer.from(rawCommand).copy(buffer, 0)
 
@@ -65,7 +65,7 @@ export class TransitionStingerCommand extends AbstractCommand {
 	}
 
 	applyToState (state: AtemState) {
-		let mixEffect = state.video.getMe(this.mixEffect)
+		const mixEffect = state.video.getMe(this.mixEffect)
 		mixEffect.transitionSettings.stinger = {
 			...this.properties
 		}

--- a/src/commands/MixEffects/Transition/TransitionWipeCommand.ts
+++ b/src/commands/MixEffects/Transition/TransitionWipeCommand.ts
@@ -41,8 +41,8 @@ export class TransitionWipeCommand extends AbstractCommand {
 	}
 
 	serialize () {
-		let rawCommand = 'CTWp'
-		let buffer = new Buffer(24)
+		const rawCommand = 'CTWp'
+		const buffer = new Buffer(24)
 		buffer.fill(0)
 		Buffer.from(rawCommand).copy(buffer, 0)
 
@@ -66,7 +66,7 @@ export class TransitionWipeCommand extends AbstractCommand {
 	}
 
 	applyToState (state: AtemState) {
-		let mixEffect = state.video.getMe(this.mixEffect)
+		const mixEffect = state.video.getMe(this.mixEffect)
 		mixEffect.transitionSettings.wipe = {
 			...this.properties
 		}

--- a/src/lib/atemCommandParser.ts
+++ b/src/lib/atemCommandParser.ts
@@ -5,9 +5,9 @@ export class CommandParser {
 	commands: {[key: string]: AbstractCommand} = {}
 
 	constructor () {
-		for (let cmd in Commands) {
+		for (const cmd in Commands) {
 			try {
-				let rawName = new (Commands as any)[cmd]().rawName
+				const rawName = new (Commands as any)[cmd]().rawName
 				this.commands[rawName] = (Commands as any)[cmd]
 			} catch (e) {
 				// wwwwhatever

--- a/src/lib/atemSocket.ts
+++ b/src/lib/atemSocket.ts
@@ -70,9 +70,9 @@ export class AtemSocket extends EventEmitter {
 	}
 
 	public _sendCommand (command: AbstractCommand) {
-		let payload = command.serialize()
+		const payload = command.serialize()
 		this.log(payload)
-		let buffer = new Buffer(16 + payload.length)
+		const buffer = new Buffer(16 + payload.length)
 		buffer.fill(0)
 
 		buffer[0] = (16 + payload.length) / 256 | 0x08
@@ -95,13 +95,13 @@ export class AtemSocket extends EventEmitter {
 	private _receivePacket (packet: Buffer, rinfo: any) {
 		this.log('RECV ', packet)
 		this._lastReceivedAt = Date.now()
-		let length = ((packet[0] & 0x07) << 8) | packet[1]
+		const length = ((packet[0] & 0x07) << 8) | packet[1]
 		if (length !== rinfo.size) return
 
-		let flags = packet[0] >> 3
+		const flags = packet[0] >> 3
 		// this._sessionId = [packet[2], packet[3]]
 		this._sessionId = packet[2] << 8 | packet[3]
-		let remotePacketId = packet[10] << 8 | packet[11]
+		const remotePacketId = packet[10] << 8 | packet[11]
 
 		// Send hello answer packet when receive connect flags
 		if (flags & PacketFlag.Connect && !(flags & PacketFlag.Repeat)) {
@@ -127,8 +127,8 @@ export class AtemSocket extends EventEmitter {
 
 		// Device ack'ed our command
 		if (flags & PacketFlag.AckReply && this._connectionState === ConnectionState.Established) {
-			let ackPacketId = packet[4] << 8 | packet[5]
-			for (let i in this._inFlight) {
+			const ackPacketId = packet[4] << 8 | packet[5]
+			for (const i in this._inFlight) {
 				if (ackPacketId >= this._inFlight[i].packetId) {
 					this.emit('commandAcknowleged', this._inFlight[i].packetId)
 					delete this._inFlight[i]
@@ -138,11 +138,11 @@ export class AtemSocket extends EventEmitter {
 	}
 
 	private _parseCommand (buffer: Buffer, packetId?: number) {
-		let length = buffer.readUInt16BE(0)
-		let name = buffer.toString('utf8', 4, 8)
+		const length = buffer.readUInt16BE(0)
+		const name = buffer.toString('utf8', 4, 8)
 
 		// this.log('COMMAND', `${name}(${length})`, buffer.slice(0, length))
-		let cmd = this._commandParser.commandFromRawName(name)
+		const cmd = this._commandParser.commandFromRawName(name)
 		if (cmd) {
 			cmd.deserialize(buffer.slice(0, length).slice(8))
 			cmd.packetId = packetId || -1
@@ -160,7 +160,7 @@ export class AtemSocket extends EventEmitter {
 	}
 
 	private _sendAck (packetId: number) {
-		let buffer = new Buffer(12)
+		const buffer = new Buffer(12)
 		buffer.fill(0)
 		buffer[0] = 0x80
 		buffer[1] = 0x0C
@@ -173,7 +173,7 @@ export class AtemSocket extends EventEmitter {
 	}
 
 	private _checkForRetransmit () {
-		for (let sentPacket of this._inFlight) {
+		for (const sentPacket of this._inFlight) {
 			if (sentPacket && sentPacket.lastSent + this._inFlightTimeout < Date.now()) {
 				if (sentPacket.resent <= this._maxRetries) {
 					sentPacket.lastSent = Date.now()

--- a/src/lib/atemUtil.ts
+++ b/src/lib/atemUtil.ts
@@ -1,7 +1,7 @@
 export namespace Util {
 	export function stringToBytes (str: string): Array<number> {
-		let array = []
-		for (let val of Buffer.from(str).values()) {
+		const array = []
+		for (const val of Buffer.from(str).values()) {
 			array.push(val)
 		}
 		return array

--- a/tslint.json
+++ b/tslint.json
@@ -4,6 +4,7 @@
     "indent": [true, "tabs", 4],
     "ter-indent": [true, "tab",{
 			"SwitchCase": 1
-		}]
+    }],
+    "prefer-const": true
   }
 }


### PR DESCRIPTION
The standard did not check for this, so it's been set as a configuration option.

I'm unsure if this should be merged before or after #3 