### PR TITLE
Enforce value ranges

### DIFF
--- a/src/atem.ts
+++ b/src/atem.ts
@@ -56,6 +56,7 @@ export class Atem extends EventEmitter {
 		})
 		this.socket.on('receivedStateChange', (command: AbstractCommand) => this._mutateState(command))
 		this.socket.on('commandAcknowleged', (packetId: number) => this._resolveCommand(packetId))
+		this.socket.on('error', (e) => this.emit('error', e))
 		this.socket.on('connect', () => this.emit('connected'))
 		this.socket.on('disconnect', () => this.emit('disconnected'))
 	}

--- a/src/commands/DeviceProfile/productIdentifierCommand.ts
+++ b/src/commands/DeviceProfile/productIdentifierCommand.ts
@@ -1,6 +1,7 @@
 import AbstractCommand from '../AbstractCommand'
 import { AtemState } from '../../state'
 import { Util } from '../../lib/atemUtil'
+import { Enums } from '../..'
 
 export class ProductIdentifierCommand extends AbstractCommand {
 	rawName = '_pin'
@@ -13,7 +14,7 @@ export class ProductIdentifierCommand extends AbstractCommand {
 	deserialize (rawCommand: Buffer) {
 		this.properties = {
 			deviceName: Util.bufToNullTerminatedString(rawCommand, 0, 32),
-			model: rawCommand[40]
+			model: Util.parseEnum<Enums.Model>(rawCommand[40], Enums.Model)
 		}
 	}
 

--- a/src/commands/DeviceProfile/superSourceConfigCommand.ts
+++ b/src/commands/DeviceProfile/superSourceConfigCommand.ts
@@ -1,5 +1,6 @@
 import AbstractCommand from '../AbstractCommand'
 import { AtemState } from '../../state'
+import { Util } from '../..'
 
 export class SuperSourceConfigCommand extends AbstractCommand {
 	rawName = '_SSC'
@@ -10,7 +11,7 @@ export class SuperSourceConfigCommand extends AbstractCommand {
 
 	deserialize (rawCommand: Buffer) {
 		this.properties = {
-			superSourceBoxes: rawCommand[0]
+			superSourceBoxes: Util.parseNumberBetween(rawCommand[0], 0, 3)
 		}
 	}
 

--- a/src/commands/DownstreamKey/DownstreamKeyPropertiesCommand.ts
+++ b/src/commands/DownstreamKey/DownstreamKeyPropertiesCommand.ts
@@ -1,6 +1,7 @@
 import AbstractCommand from '../AbstractCommand'
 import { AtemState } from '../../state'
 import { DownstreamKeyerProperties } from '../../state/video/downstreamKeyers'
+import { Util } from '../..'
 
 export class DownstreamKeyPropertiesCommand extends AbstractCommand {
 	rawName = 'DskP'
@@ -11,19 +12,19 @@ export class DownstreamKeyPropertiesCommand extends AbstractCommand {
 		this.downstreamKeyerId = rawCommand[0]
 		this.properties = {
 			tie: rawCommand[1] === 1,
-			rate: rawCommand[2],
+			rate: Util.parseNumberBetween(rawCommand[2], 0, 300),
 
 			preMultiply: rawCommand[3] === 1,
-			clip: rawCommand.readUInt16BE(4),
-			gain: rawCommand.readUInt16BE(6),
+			clip: Util.parseNumberBetween(rawCommand.readUInt16BE(4), 0, 1000),
+			gain: Util.parseNumberBetween(rawCommand.readUInt16BE(6), 0, 1000),
 			invert: rawCommand[8] === 1,
 
 			mask: {
 				enabled: rawCommand[9] === 1,
-				top: rawCommand.readInt16BE(10),
-				bottom: rawCommand.readInt16BE(12),
-				left: rawCommand.readInt16BE(14),
-				right: rawCommand.readInt16BE(16)
+				top: Util.parseNumberBetween(rawCommand.readInt16BE(10), -9000, 9000),
+				bottom: Util.parseNumberBetween(rawCommand.readInt16BE(12), -9000, 9000),
+				left: Util.parseNumberBetween(rawCommand.readInt16BE(14), -16000, 16000),
+				right: Util.parseNumberBetween(rawCommand.readInt16BE(16), -16000, 16000)
 			}
 		}
 	}

--- a/src/commands/DownstreamKey/DownstreamKeySourcesCommand.ts
+++ b/src/commands/DownstreamKey/DownstreamKeySourcesCommand.ts
@@ -1,5 +1,6 @@
 import AbstractCommand from '../AbstractCommand'
 import { AtemState } from '../../state'
+import { Util } from '../..'
 
 export class DownstreamKeySourcesCommand extends AbstractCommand {
 	rawName = 'DskB'
@@ -10,7 +11,7 @@ export class DownstreamKeySourcesCommand extends AbstractCommand {
 	}
 
 	deserialize (rawCommand: Buffer) {
-		this.downstreamKeyerId = rawCommand[0]
+		this.downstreamKeyerId = Util.parseNumberBetween(rawCommand[0], 0, 3),
 		this.properties = {
 			fillSource: rawCommand.readInt16BE(2),
 			cutSource: rawCommand.readInt16BE(4)

--- a/src/commands/DownstreamKey/DownstreamKeyStateCommand.ts
+++ b/src/commands/DownstreamKey/DownstreamKeyStateCommand.ts
@@ -1,6 +1,7 @@
 import AbstractCommand from '../AbstractCommand'
 import { AtemState } from '../../state'
 import { DownstreamKeyerBase } from '../../state/video/downstreamKeyers'
+import { Util } from '../..'
 
 export class DownstreamKeyStateCommand extends AbstractCommand {
 	rawName = 'DskS'
@@ -9,7 +10,7 @@ export class DownstreamKeyStateCommand extends AbstractCommand {
 	properties: DownstreamKeyerBase
 
 	deserialize (rawCommand: Buffer) {
-		this.downstreamKeyId = rawCommand[0]
+		this.downstreamKeyId = Util.parseNumberBetween(rawCommand[0], 0, 3)
 		this.properties = {
 			onAir: rawCommand[1] === 1,
 			inTransition: rawCommand[2] === 1,

--- a/src/commands/Media/MediaPlayerStatusCommand.ts
+++ b/src/commands/Media/MediaPlayerStatusCommand.ts
@@ -1,6 +1,7 @@
 import { AtemState } from '../../state'
 import { MediaPlayer } from '../../state/media'
 import AbstractCommand from '../AbstractCommand'
+import { Util } from '../../lib/atemUtil'
 
 export class MediaPlayerStatusCommand extends AbstractCommand {
 	static MaskFlags = {
@@ -20,7 +21,7 @@ export class MediaPlayerStatusCommand extends AbstractCommand {
 	}
 
 	deserialize (rawCommand: Buffer) {
-		this.mediaPlayerId = rawCommand[0]
+		this.mediaPlayerId = Util.parseNumberBetween(rawCommand[0], 0, 3)
 		this.properties = {
 			playing: rawCommand[1] === 1,
 			loop: rawCommand[2] === 1,

--- a/src/commands/MixEffects/AutoTransitionCommand.ts
+++ b/src/commands/MixEffects/AutoTransitionCommand.ts
@@ -1,4 +1,5 @@
 import AbstractCommand from '../AbstractCommand'
+import { Util } from '../..'
 
 export class AutoTransitionCommand extends AbstractCommand {
 	rawName = 'DAut'
@@ -7,7 +8,7 @@ export class AutoTransitionCommand extends AbstractCommand {
 	properties: null
 
 	deserialize (rawCommand: Buffer) {
-		this.mixEffect = rawCommand[0]
+		this.mixEffect = Util.parseNumberBetween(rawCommand[0], 0, 3)
 	}
 
 	serialize () {

--- a/src/commands/MixEffects/CutCommand.ts
+++ b/src/commands/MixEffects/CutCommand.ts
@@ -1,4 +1,5 @@
 import AbstractCommand from '../AbstractCommand'
+import { Util } from '../..'
 
 export class CutCommand extends AbstractCommand {
 	rawName = 'DCut'
@@ -7,7 +8,7 @@ export class CutCommand extends AbstractCommand {
 	properties: null
 
 	deserialize (rawCommand: Buffer) {
-		this.mixEffect = rawCommand[0]
+		this.mixEffect = Util.parseNumberBetween(rawCommand[0], 0, 3)
 	}
 
 	serialize () {

--- a/src/commands/MixEffects/Key/MixEffectKeyChromaCommand.ts
+++ b/src/commands/MixEffects/Key/MixEffectKeyChromaCommand.ts
@@ -1,6 +1,7 @@
 import AbstractCommand from '../../AbstractCommand'
 import { AtemState } from '../../../state'
 import { UpstreamKeyerChromaSettings } from '../../../state/video/upstreamKeyers'
+import { Util } from '../../..'
 
 export class MixEffectKeyChromaCommand extends AbstractCommand {
 	static MaskFlags = {
@@ -17,13 +18,13 @@ export class MixEffectKeyChromaCommand extends AbstractCommand {
 	properties: UpstreamKeyerChromaSettings
 
 	deserialize (rawCommand: Buffer) {
-		this.mixEffect = rawCommand[0]
-		this.upstreamKeyerId = rawCommand[1]
+		this.mixEffect = Util.parseNumberBetween(rawCommand[0], 0, 3)
+		this.upstreamKeyerId = Util.parseNumberBetween(rawCommand[1], 0, 3)
 		this.properties = {
-			hue: rawCommand.readUInt16BE(2),
-			gain: rawCommand.readUInt16BE(4),
-			ySuppress: rawCommand.readUInt16BE(6),
-			lift: rawCommand.readUInt16BE(8),
+			hue: Util.parseNumberBetween(rawCommand.readUInt16BE(2), 0, 3599),
+			gain: Util.parseNumberBetween(rawCommand.readUInt16BE(4), 0, 1000),
+			ySuppress: Util.parseNumberBetween(rawCommand.readUInt16BE(6), 0, 1000),
+			lift: Util.parseNumberBetween(rawCommand.readUInt16BE(8), 0, 1000),
 			narrow: rawCommand[10] === 1
 		}
 	}

--- a/src/commands/MixEffects/Key/MixEffectKeyDVECommand.ts
+++ b/src/commands/MixEffects/Key/MixEffectKeyDVECommand.ts
@@ -1,6 +1,7 @@
 import AbstractCommand from '../../AbstractCommand'
 import { AtemState } from '../../../state'
 import { UpstreamKeyerDVESettings } from '../../../state/video/upstreamKeyers'
+import { Util, Enums } from '../../..'
 
 export class MixEffectKeyDVECommand extends AbstractCommand {
 	static MaskFlags = {
@@ -38,40 +39,40 @@ export class MixEffectKeyDVECommand extends AbstractCommand {
 	properties: UpstreamKeyerDVESettings
 
 	deserialize (rawCommand: Buffer) {
-		this.mixEffect = rawCommand[0]
-		this.upstreamKeyerId = rawCommand[1]
+		this.mixEffect = Util.parseNumberBetween(rawCommand[0], 0, 3)
+		this.upstreamKeyerId = Util.parseNumberBetween(rawCommand[1], 0, 3)
 		this.properties = {
-			sizeX: rawCommand.readUInt32BE(4),
-			sizeY: rawCommand.readUInt32BE(8),
-			positionX: rawCommand.readInt32BE(12),
-			positionY: rawCommand.readInt32BE(16),
-			rotation: rawCommand.readInt32BE(20),
+			sizeX: Util.parseNumberBetween(rawCommand.readUInt32BE(4), 0, 99990),
+			sizeY: Util.parseNumberBetween(rawCommand.readUInt32BE(8), 0, 99990),
+			positionX: Util.parseNumberBetween(rawCommand.readInt32BE(12), -1000 * 1000, 1000 * 1000),
+			positionY: Util.parseNumberBetween(rawCommand.readInt32BE(16), -1000 * 1000, 1000 * 1000),
+			rotation: Util.parseNumberBetween(rawCommand.readInt32BE(20), -332230, 332230),
 
 			borderEnabled: rawCommand[24] === 1,
 			shadowEnabled: rawCommand[25] === 1,
-			borderBevel: rawCommand.readUInt8(26),
-			borderOuterWidth: rawCommand.readUInt16BE(28),
-			borderInnerWidth: rawCommand.readUInt16BE(30),
-			borderOuterSoftness: rawCommand.readInt8(32),
-			borderInnerSoftness: rawCommand.readInt8(33),
-			borderBevelSoftness: rawCommand.readInt8(34),
-			borderBevelPosition: rawCommand.readInt8(35),
+			borderBevel: Util.parseEnum<Enums.BorderBevel>(rawCommand.readUInt8(26), Enums.BorderBevel),
+			borderOuterWidth: Util.parseNumberBetween(rawCommand.readUInt16BE(28), 0, 1600),
+			borderInnerWidth: Util.parseNumberBetween(rawCommand.readUInt16BE(30), 0, 1600),
+			borderOuterSoftness: Util.parseNumberBetween(rawCommand.readInt8(32), 0, 100),
+			borderInnerSoftness: Util.parseNumberBetween(rawCommand.readInt8(33), 0, 100),
+			borderBevelSoftness: Util.parseNumberBetween(rawCommand.readInt8(34), 0, 100),
+			borderBevelPosition: Util.parseNumberBetween(rawCommand.readInt8(35), 0, 100),
 
-			borderOpacity: rawCommand.readInt8(36),
-			borderHue: rawCommand.readUInt16BE(38),
-			borderSaturation: rawCommand.readUInt16BE(40),
-			borderLuma: rawCommand.readUInt16BE(42),
+			borderOpacity: Util.parseNumberBetween(rawCommand.readInt8(36), 0, 100),
+			borderHue: Util.parseNumberBetween(rawCommand.readUInt16BE(38), 0, 1000),
+			borderSaturation: Util.parseNumberBetween(rawCommand.readUInt16BE(40), 0, 1000),
+			borderLuma: Util.parseNumberBetween(rawCommand.readUInt16BE(42), 0, 1000),
 
-			lightSourceDirection: rawCommand.readUInt16BE(44),
-			lightSourceAltitude: rawCommand.readUInt8(46),
+			lightSourceDirection: Util.parseNumberBetween(rawCommand.readUInt16BE(44), 0, 3599),
+			lightSourceAltitude: Util.parseNumberBetween(rawCommand.readUInt8(46), 0, 100),
 
 			maskEnabled: rawCommand[47] === 1,
-			maskTop: rawCommand.readUInt16BE(48),
-			maskBottom: rawCommand.readUInt16BE(50),
-			maskLeft: rawCommand.readUInt16BE(52),
-			maskRight: rawCommand.readUInt16BE(54),
+			maskTop: Util.parseNumberBetween(rawCommand.readUInt16BE(48), 0, 38000),
+			maskBottom: Util.parseNumberBetween(rawCommand.readUInt16BE(50), 0, 38000),
+			maskLeft: Util.parseNumberBetween(rawCommand.readUInt16BE(52), 0, 52000),
+			maskRight: Util.parseNumberBetween(rawCommand.readUInt16BE(54), 0, 52000),
 
-			rate: rawCommand.readInt8(56)
+			rate: Util.parseNumberBetween(rawCommand.readInt8(56), 0, 250)
 		}
 	}
 

--- a/src/commands/MixEffects/Key/MixEffectKeyFlyKeyframeGetCommand.ts
+++ b/src/commands/MixEffects/Key/MixEffectKeyFlyKeyframeGetCommand.ts
@@ -13,7 +13,7 @@ export class MixEffectKeyFlyKeyframeGetCommand extends AbstractCommand {
 		this.mixEffect = Util.parseNumberBetween(rawCommand[0], 0, 3)
 		this.upstreamKeyerId = Util.parseNumberBetween(rawCommand[1], 0, 3)
 		this.properties = {
-			keyFrameId: Util.parseNumberBetween(rawCommand[2], 0, 1),
+			keyFrameId: Util.parseNumberBetween(rawCommand[2], 1, 2),
 
 			sizeX: Util.parseNumberBetween(rawCommand.readUInt32BE(4), 0, 99990),
 			sizeY: Util.parseNumberBetween(rawCommand.readUInt32BE(8), 0, 99990),

--- a/src/commands/MixEffects/Key/MixEffectKeyFlyKeyframeGetCommand.ts
+++ b/src/commands/MixEffects/Key/MixEffectKeyFlyKeyframeGetCommand.ts
@@ -1,6 +1,7 @@
 import AbstractCommand from '../../AbstractCommand'
 import { AtemState } from '../../../state'
 import { UpstreamKeyerFlyKeyframe } from '../../../state/video/upstreamKeyers'
+import { Util } from '../../..'
 
 export class MixEffectKeyFlyKeyframeGetCommand extends AbstractCommand {
 	rawName = 'KKFP'
@@ -9,37 +10,37 @@ export class MixEffectKeyFlyKeyframeGetCommand extends AbstractCommand {
 	properties: UpstreamKeyerFlyKeyframe
 
 	deserialize (rawCommand: Buffer) {
-		this.mixEffect = rawCommand[0]
-		this.upstreamKeyerId = rawCommand[1]
+		this.mixEffect = Util.parseNumberBetween(rawCommand[0], 0, 3)
+		this.upstreamKeyerId = Util.parseNumberBetween(rawCommand[1], 0, 3)
 		this.properties = {
-			keyFrameId: rawCommand[2],
+			keyFrameId: Util.parseNumberBetween(rawCommand[2], 0, 1),
 
-			sizeX: rawCommand.readUInt32BE(4),
-			sizeY: rawCommand.readUInt32BE(8),
-			positionX: rawCommand.readInt32BE(12),
-			positionY: rawCommand.readInt32BE(16),
-			rotation: rawCommand.readInt32BE(20),
+			sizeX: Util.parseNumberBetween(rawCommand.readUInt32BE(4), 0, 99990),
+			sizeY: Util.parseNumberBetween(rawCommand.readUInt32BE(8), 0, 99990),
+			positionX: Util.parseNumberBetween(rawCommand.readInt32BE(12), -1000 * 1000, 1000 * 1000),
+			positionY: Util.parseNumberBetween(rawCommand.readInt32BE(16), -1000 * 1000, 1000 * 1000),
+			rotation: Util.parseNumberBetween(rawCommand.readInt32BE(20), -332230, 332230),
 
-			borderOuterWidth: rawCommand.readUInt16BE(24),
-			borderInnerWidth: rawCommand.readUInt16BE(26),
-			borderOuterSoftness: rawCommand.readInt8(28),
-			borderInnerSoftness: rawCommand.readInt8(29),
-			borderBevelSoftness: rawCommand.readInt8(30),
-			borderBevelPosition: rawCommand.readInt8(31),
+			borderOuterWidth: Util.parseNumberBetween(rawCommand.readUInt16BE(24), 0, 1600),
+			borderInnerWidth: Util.parseNumberBetween(rawCommand.readUInt16BE(26), 0, 1600),
+			borderOuterSoftness: Util.parseNumberBetween(rawCommand.readInt8(28), 0, 100),
+			borderInnerSoftness: Util.parseNumberBetween(rawCommand.readInt8(29), 0, 100),
+			borderBevelSoftness: Util.parseNumberBetween(rawCommand.readInt8(30), 0, 100),
+			borderBevelPosition: Util.parseNumberBetween(rawCommand.readInt8(31), 0, 100),
 
-			borderOpacity: rawCommand.readInt8(32),
-			borderHue: rawCommand.readUInt16BE(34),
-			borderSaturation: rawCommand.readUInt16BE(36),
-			borderLuma: rawCommand.readUInt16BE(38),
+			borderOpacity: Util.parseNumberBetween(rawCommand.readInt8(32), 0, 100),
+			borderHue: Util.parseNumberBetween(rawCommand.readUInt16BE(34), 0, 1000),
+			borderSaturation: Util.parseNumberBetween(rawCommand.readUInt16BE(36), 0, 1000),
+			borderLuma: Util.parseNumberBetween(rawCommand.readUInt16BE(38), 0, 1000),
 
-			lightSourceDirection: rawCommand.readUInt16BE(40),
-			lightSourceAltitude: rawCommand.readUInt8(42),
+			lightSourceDirection: Util.parseNumberBetween(rawCommand.readUInt16BE(40), 0, 3599),
+			lightSourceAltitude: Util.parseNumberBetween(rawCommand.readUInt8(42), 0, 100),
 
 			maskEnabled: rawCommand[43] === 1,
-			maskTop: rawCommand.readUInt16BE(44),
-			maskBottom: rawCommand.readUInt16BE(46),
-			maskLeft: rawCommand.readUInt16BE(48),
-			maskRight: rawCommand.readUInt16BE(50)
+			maskTop: Util.parseNumberBetween(rawCommand.readUInt16BE(44), 0, 38000),
+			maskBottom: Util.parseNumberBetween(rawCommand.readUInt16BE(46), 0, 38000),
+			maskLeft: Util.parseNumberBetween(rawCommand.readUInt16BE(48), 0, 52000),
+			maskRight: Util.parseNumberBetween(rawCommand.readUInt16BE(50), 0, 52000)
 		}
 	}
 

--- a/src/commands/MixEffects/Key/MixEffectKeyFlyPropertiesGetCommand.ts
+++ b/src/commands/MixEffects/Key/MixEffectKeyFlyPropertiesGetCommand.ts
@@ -1,6 +1,7 @@
 import AbstractCommand from '../../AbstractCommand'
 import { AtemState } from '../../../state'
 import { UpstreamKeyerFlySettings } from '../../../state/video/upstreamKeyers'
+import { Util } from '../../..'
 
 export class MixEffectKeyFlyPropertiesGetCommand extends AbstractCommand {
 	rawName = 'KeFS'
@@ -9,8 +10,8 @@ export class MixEffectKeyFlyPropertiesGetCommand extends AbstractCommand {
 	properties: UpstreamKeyerFlySettings
 
 	deserialize (rawCommand: Buffer) {
-		this.mixEffect = rawCommand[0]
-		this.upstreamKeyerId = rawCommand[1]
+		this.mixEffect = Util.parseNumberBetween(rawCommand[0], 0, 3)
+		this.upstreamKeyerId = Util.parseNumberBetween(rawCommand[1], 0, 3)
 		this.properties = {
 			isASet: rawCommand[2] === 1,
 			isBSet: rawCommand[3] === 1,

--- a/src/commands/MixEffects/Key/MixEffectKeyLumaCommand.ts
+++ b/src/commands/MixEffects/Key/MixEffectKeyLumaCommand.ts
@@ -1,6 +1,7 @@
 import AbstractCommand from '../../AbstractCommand'
 import { AtemState } from '../../../state'
 import { UpstreamKeyerLumaSettings } from '../../../state/video/upstreamKeyers'
+import { Util } from '../../..'
 
 export class MixEffectKeyLumaCommand extends AbstractCommand {
 	static MaskFlags = {
@@ -16,12 +17,12 @@ export class MixEffectKeyLumaCommand extends AbstractCommand {
 	properties: UpstreamKeyerLumaSettings
 
 	deserialize (rawCommand: Buffer) {
-		this.mixEffect = rawCommand[0]
-		this.upstreamKeyerId = rawCommand[1]
+		this.mixEffect = Util.parseNumberBetween(rawCommand[0], 0, 3)
+		this.upstreamKeyerId = Util.parseNumberBetween(rawCommand[1], 0, 3)
 		this.properties = {
 			preMultiplied: rawCommand[2] === 1,
-			clip: rawCommand.readUInt16BE(4),
-			gain: rawCommand.readUInt16BE(6),
+			clip: Util.parseNumberBetween(rawCommand.readUInt16BE(4), 0, 1000),
+			gain: Util.parseNumberBetween(rawCommand.readUInt16BE(6), 0, 1000),
 			invert: rawCommand[8] === 1
 		}
 	}

--- a/src/commands/MixEffects/Key/MixEffectKeyOnAirCommand.ts
+++ b/src/commands/MixEffects/Key/MixEffectKeyOnAirCommand.ts
@@ -1,5 +1,6 @@
 import AbstractCommand from '../../AbstractCommand'
 import { AtemState } from '../../../state'
+import { Util } from '../../..'
 
 export class MixEffectKeyOnAirCommand extends AbstractCommand {
 	rawName = 'KeOn'
@@ -10,8 +11,8 @@ export class MixEffectKeyOnAirCommand extends AbstractCommand {
 	}
 
 	deserialize (rawCommand: Buffer) {
-		this.mixEffect = rawCommand[0]
-		this.upstreamKeyerId = rawCommand[1]
+		this.mixEffect = Util.parseNumberBetween(rawCommand[0], 0, 3)
+		this.upstreamKeyerId = Util.parseNumberBetween(rawCommand[1], 0, 3)
 		this.properties = {
 			onAir: rawCommand[2] === 1
 		}

--- a/src/commands/MixEffects/Key/MixEffectKeyPatternCommand.ts
+++ b/src/commands/MixEffects/Key/MixEffectKeyPatternCommand.ts
@@ -1,6 +1,7 @@
 import AbstractCommand from '../../AbstractCommand'
 import { AtemState } from '../../../state'
 import { UpstreamKeyerPatternSettings } from '../../../state/video/upstreamKeyers'
+import { Util, Enums } from '../../..'
 
 export class MixEffectKeyPatternCommand extends AbstractCommand {
 	static MaskFlags = {
@@ -19,15 +20,15 @@ export class MixEffectKeyPatternCommand extends AbstractCommand {
 	properties: UpstreamKeyerPatternSettings
 
 	deserialize (rawCommand: Buffer) {
-		this.mixEffect = rawCommand[0]
-		this.upstreamKeyerId = rawCommand[1]
+		this.mixEffect = Util.parseNumberBetween(rawCommand[0], 0, 3)
+		this.upstreamKeyerId = Util.parseNumberBetween(rawCommand[1], 0, 3)
 		this.properties = {
-			style: rawCommand[2],
-			size: rawCommand.readUInt16BE(4),
-			symmetry: rawCommand.readUInt16BE(6),
-			softness: rawCommand.readUInt16BE(8),
-			positionX: rawCommand.readUInt16BE(10),
-			positionY: rawCommand.readUInt16BE(12),
+			style: Util.parseEnum<Enums.Pattern>(rawCommand[2], Enums.Pattern),
+			size: Util.parseNumberBetween(rawCommand.readUInt16BE(4), 0, 10000),
+			symmetry: Util.parseNumberBetween(rawCommand.readUInt16BE(6), 0, 10000),
+			softness: Util.parseNumberBetween(rawCommand.readUInt16BE(8), 0, 10000),
+			positionX: Util.parseNumberBetween(rawCommand.readUInt16BE(10), 0, 10000),
+			positionY: Util.parseNumberBetween(rawCommand.readUInt16BE(12), 0, 10000),
 			invert: rawCommand[14] === 1
 		}
 	}

--- a/src/commands/MixEffects/Key/MixEffectKeyPropertiesGetCommand.ts
+++ b/src/commands/MixEffects/Key/MixEffectKeyPropertiesGetCommand.ts
@@ -1,6 +1,7 @@
 import AbstractCommand from '../../AbstractCommand'
 import { AtemState } from '../../../state'
 import { UpstreamKeyerBase } from '../../../state/video/upstreamKeyers'
+import { Util, Enums } from '../../..'
 
 export class MixEffectKeyPropertiesGetCommand extends AbstractCommand {
 	rawName = 'KeBP'
@@ -8,18 +9,18 @@ export class MixEffectKeyPropertiesGetCommand extends AbstractCommand {
 	properties: UpstreamKeyerBase
 
 	deserialize (rawCommand: Buffer) {
-		this.mixEffect = rawCommand[0]
+		this.mixEffect = Util.parseNumberBetween(rawCommand[0], 0, 3)
 		this.properties = {
-			upstreamKeyerId: rawCommand[1],
-			mixEffectKeyType: rawCommand[2],
+			upstreamKeyerId: Util.parseNumberBetween(rawCommand[1], 0, 3),
+			mixEffectKeyType: Util.parseEnum<Enums.MixEffectKeyType>(rawCommand[2], Enums.MixEffectKeyType),
 			flyEnabled: rawCommand[5] === 1,
 			fillSource: rawCommand.readUInt16BE(6),
 			cutSource: rawCommand.readUInt16BE(8),
 			maskEnabled: rawCommand[10] === 1,
-			maskTop: rawCommand.readInt16BE(12),
-			maskBottom: rawCommand.readInt16BE(14),
-			maskLeft: rawCommand.readInt16BE(16),
-			maskRight: rawCommand.readInt16BE(18)
+			maskTop: Util.parseNumberBetween(rawCommand.readInt16BE(12), -9000, 9000),
+			maskBottom: Util.parseNumberBetween(rawCommand.readInt16BE(14), -9000, 9000),
+			maskLeft: Util.parseNumberBetween(rawCommand.readInt16BE(16), -16000, 16000),
+			maskRight: Util.parseNumberBetween(rawCommand.readInt16BE(18), -16000, 16000)
 		}
 	}
 

--- a/src/commands/MixEffects/PreviewInputCommand.ts
+++ b/src/commands/MixEffects/PreviewInputCommand.ts
@@ -1,5 +1,6 @@
 import AbstractCommand from '../AbstractCommand'
 import { AtemState } from '../../state'
+import { Util } from '../..'
 
 export class PreviewInputCommand extends AbstractCommand {
 	rawName = 'PrvI'
@@ -10,7 +11,7 @@ export class PreviewInputCommand extends AbstractCommand {
 	}
 
 	deserialize (rawCommand: Buffer) {
-		this.mixEffect = rawCommand[0]
+		this.mixEffect = Util.parseNumberBetween(rawCommand[0], 0, 3)
 		this.properties = {
 			source: rawCommand.readUInt16BE(2)
 		}

--- a/src/commands/MixEffects/ProgramInputCommand.ts
+++ b/src/commands/MixEffects/ProgramInputCommand.ts
@@ -1,5 +1,6 @@
 import AbstractCommand from '../AbstractCommand'
 import { AtemState } from '../../state'
+import { Util } from '../..'
 
 export class ProgramInputCommand extends AbstractCommand {
 	rawName = 'PrgI'
@@ -10,7 +11,7 @@ export class ProgramInputCommand extends AbstractCommand {
 	}
 
 	deserialize (rawCommand: Buffer) {
-		this.mixEffect = rawCommand[0]
+		this.mixEffect = Util.parseNumberBetween(rawCommand[0], 0, 3)
 		this.properties = {
 			source: rawCommand.readUInt16BE(2)
 		}

--- a/src/commands/MixEffects/Transition/TransitionDVECommand.ts
+++ b/src/commands/MixEffects/Transition/TransitionDVECommand.ts
@@ -1,6 +1,7 @@
 import AbstractCommand from '../../AbstractCommand'
 import { AtemState } from '../../../state'
 import { DVETransitionSettings } from '../../../state/video'
+import { Util, Enums } from '../../..'
 
 export class TransitionDVECommand extends AbstractCommand {
 	static MaskFlags = {
@@ -28,18 +29,18 @@ export class TransitionDVECommand extends AbstractCommand {
 	}
 
 	deserialize (rawCommand: Buffer) {
-		this.mixEffect = rawCommand[0]
+		this.mixEffect = Util.parseNumberBetween(rawCommand[0], 0, 3)
 		this.properties = {
-			rate: rawCommand[1],
-			logoRate: rawCommand[2],
-			style: rawCommand[3],
+			rate: Util.parseNumberBetween(rawCommand[1], 1, 250),
+			logoRate: Util.parseNumberBetween(rawCommand[2], 1, 250),
+			style: Util.parseEnum<Enums.DVEEffect>(rawCommand[3], Enums.DVEEffect),
 			fillSource: rawCommand[4] << 8 | (rawCommand[5] & 0xff),
 			keySource: rawCommand[6] << 8 | (rawCommand[7] & 0xff),
 
 			enableKey: rawCommand[8] === 1,
 			preMultiplied: rawCommand[9] === 1,
-			clip: rawCommand[10] << 8 | (rawCommand[11] & 0xff),
-			gain: rawCommand[12] << 8 | (rawCommand[13] & 0xff),
+			clip: Util.parseNumberBetween(rawCommand.readUInt16BE(10), 0, 1000),
+			gain: Util.parseNumberBetween(rawCommand.readUInt16BE(12), 0, 1000),
 			invertKey: rawCommand[14] === 1,
 			reverse: rawCommand[15] === 1,
 			flipFlop: rawCommand[16] === 1

--- a/src/commands/MixEffects/Transition/TransitionDipCommand.ts
+++ b/src/commands/MixEffects/Transition/TransitionDipCommand.ts
@@ -1,6 +1,7 @@
 import AbstractCommand from '../../AbstractCommand'
 import { AtemState } from '../../../state'
 import { DipTransitionSettings } from '../../../state/video'
+import { Util } from '../../..'
 
 export class TransitionDipCommand extends AbstractCommand {
 	static MaskFlags = {
@@ -18,9 +19,9 @@ export class TransitionDipCommand extends AbstractCommand {
 	}
 
 	deserialize (rawCommand: Buffer) {
-		this.mixEffect = rawCommand[0]
+		this.mixEffect = Util.parseNumberBetween(rawCommand[0], 0, 3)
 		this.properties = {
-			rate: rawCommand[1],
+			rate: Util.parseNumberBetween(rawCommand[1], 0, 250),
 			input: rawCommand[2] << 8 | (rawCommand[3] & 0xFF)
 		}
 	}

--- a/src/commands/MixEffects/Transition/TransitionMixCommand.ts
+++ b/src/commands/MixEffects/Transition/TransitionMixCommand.ts
@@ -1,6 +1,7 @@
 import AbstractCommand from '../../AbstractCommand'
 import { AtemState } from '../../../state'
 import { MixTransitionSettings} from '../../../state/video'
+import { Util } from '../../..'
 
 export class TransitionMixCommand extends AbstractCommand {
 	rawName = 'TMxP'
@@ -13,9 +14,9 @@ export class TransitionMixCommand extends AbstractCommand {
 	}
 
 	deserialize (rawCommand: Buffer) {
-		this.mixEffect = rawCommand[0]
+		this.mixEffect = Util.parseNumberBetween(rawCommand[0], 0, 3)
 		this.properties = {
-			rate: rawCommand[1]
+			rate: Util.parseNumberBetween(rawCommand[1], 1, 250)
 		}
 	}
 

--- a/src/commands/MixEffects/Transition/TransitionPositionCommand.ts
+++ b/src/commands/MixEffects/Transition/TransitionPositionCommand.ts
@@ -1,5 +1,6 @@
 import AbstractCommand from '../../AbstractCommand'
 import { AtemState } from '../../../state'
+import { Util } from '../../..'
 
 export class TransitionPositionCommand extends AbstractCommand {
 	rawName = 'TrPs' // this seems unnecessary.
@@ -12,11 +13,11 @@ export class TransitionPositionCommand extends AbstractCommand {
 	}
 
 	deserialize (rawCommand: Buffer) {
-		this.mixEffect = rawCommand[0]
+		this.mixEffect = Util.parseNumberBetween(rawCommand[0], 0, 3)
 		this.properties = {
 			inTransition: rawCommand[1] === 1,
-			remainingFrames: rawCommand[2],
-			handlePosition: rawCommand[4] << 8 | rawCommand[4]
+			remainingFrames: Util.parseNumberBetween(rawCommand[2], 0, 250),
+			handlePosition: Util.parseNumberBetween(rawCommand.readUInt16BE(4), 0, 9999)
 		}
 	}
 

--- a/src/commands/MixEffects/Transition/TransitionPreviewCommand.ts
+++ b/src/commands/MixEffects/Transition/TransitionPreviewCommand.ts
@@ -1,5 +1,6 @@
 import AbstractCommand from '../../AbstractCommand'
 import { AtemState } from '../../../state'
+import { Util } from '../../..'
 
 export class PreviewTransitionCommand extends AbstractCommand {
 	rawName = 'TrPr' // this seems unnecessary.
@@ -10,7 +11,7 @@ export class PreviewTransitionCommand extends AbstractCommand {
 	}
 
 	deserialize (rawCommand: Buffer) {
-		this.mixEffect = rawCommand[0]
+		this.mixEffect = Util.parseNumberBetween(rawCommand[0], 0, 3)
 		this.properties = {
 			preview: rawCommand[1] === 1
 		}

--- a/src/commands/MixEffects/Transition/TransitionPropertiesCommand.ts
+++ b/src/commands/MixEffects/Transition/TransitionPropertiesCommand.ts
@@ -1,6 +1,7 @@
 import AbstractCommand from '../../AbstractCommand'
 import { AtemState } from '../../../state'
 import { TransitionProperties } from '../../../state/video'
+import { Util, Enums } from '../../..'
 
 export class TransitionPropertiesCommand extends AbstractCommand {
 	static MaskFlags = {
@@ -18,11 +19,11 @@ export class TransitionPropertiesCommand extends AbstractCommand {
 	}
 
 	deserialize (rawCommand: Buffer) {
-		this.mixEffect = rawCommand[0]
+		this.mixEffect = Util.parseNumberBetween(rawCommand[0], 0, 3)
 		this.properties = {
-			style: rawCommand[1],
+			style: Util.parseEnum<Enums.TransitionStyle>(rawCommand[1], Enums.TransitionStyle),// rawCommand[1],
 			selection: rawCommand[2],
-			nextStyle: rawCommand[3],
+			nextStyle: Util.parseEnum<Enums.TransitionStyle>(rawCommand[3], Enums.TransitionStyle),
 			nextSelection: rawCommand[4]
 		}
 	}

--- a/src/commands/MixEffects/Transition/TransitionStingerCommand.ts
+++ b/src/commands/MixEffects/Transition/TransitionStingerCommand.ts
@@ -1,6 +1,7 @@
 import AbstractCommand from '../../AbstractCommand'
 import { AtemState } from '../../../state'
 import { StingerTransitionSettings } from '../../../state/video'
+import { Util } from '../../..'
 
 export class TransitionStingerCommand extends AbstractCommand {
 	static MaskFlags = {
@@ -25,13 +26,13 @@ export class TransitionStingerCommand extends AbstractCommand {
 	}
 
 	deserialize (rawCommand: Buffer) {
-		this.mixEffect = rawCommand[0]
+		this.mixEffect = Util.parseNumberBetween(rawCommand[0], 0, 3)
 		this.properties = {
 			source: rawCommand[1],
 			preMultipliedKey: rawCommand[2] === 1,
 
-			clip: rawCommand[4] << 8 | rawCommand[5],
-			gain: rawCommand[6] << 8 | rawCommand[7],
+			clip: Util.parseNumberBetween(rawCommand.readUInt16BE(4), 0, 1000),
+			gain: Util.parseNumberBetween(rawCommand.readUInt16BE(6), 0, 1000),
 			invert: rawCommand[8] === 1,
 
 			preroll: rawCommand[10] << 8 | rawCommand[11],

--- a/src/commands/MixEffects/Transition/TransitionWipeCommand.ts
+++ b/src/commands/MixEffects/Transition/TransitionWipeCommand.ts
@@ -1,6 +1,7 @@
 import AbstractCommand from '../../AbstractCommand'
 import { AtemState } from '../../../state'
 import { WipeTransitionSettings } from '../../../state/video'
+import { Util, Enums } from '../../..'
 
 export class TransitionWipeCommand extends AbstractCommand {
 	static MaskFlags = {
@@ -26,16 +27,16 @@ export class TransitionWipeCommand extends AbstractCommand {
 	}
 
 	deserialize (rawCommand: Buffer) {
-		this.mixEffect = rawCommand[0]
+		this.mixEffect = Util.parseNumberBetween(rawCommand[0], 0, 3)
 		this.properties = {
-			rate: rawCommand[1],
-			pattern: rawCommand[2],
-			borderWidth: rawCommand[4] << 8 | rawCommand[5],
-			borderInput: rawCommand[6] << 8 | rawCommand[7],
-			symmetry: rawCommand[8] << 8 | rawCommand[9],
-			borderSoftness: rawCommand[10] << 8 | rawCommand[11],
-			xPosition: rawCommand[12] << 8 | rawCommand[13],
-			yPosition: rawCommand[14] << 8 | rawCommand[15],
+			rate: Util.parseNumberBetween(rawCommand[1], 1, 250),
+			pattern: Util.parseEnum<Enums.Pattern>(rawCommand[2], Enums.Pattern),
+			borderWidth: Util.parseNumberBetween(rawCommand.readUInt16BE(4), 0, 10000),
+			borderInput: rawCommand.readUInt16BE(6),
+			symmetry: Util.parseNumberBetween(rawCommand.readUInt16BE(8), 0, 10000),
+			borderSoftness: Util.parseNumberBetween(rawCommand.readUInt16BE(10), 0, 10000),
+			xPosition: Util.parseNumberBetween(rawCommand.readUInt16BE(12), 0, 10000),
+			yPosition: Util.parseNumberBetween(rawCommand.readUInt16BE(14), 0, 10000),
 			reverseDirection: rawCommand[16] === 1,
 			flipFlop: rawCommand[17] === 1
 		}

--- a/src/commands/SuperSource/SuperSourceBoxParametersCommand.ts
+++ b/src/commands/SuperSource/SuperSourceBoxParametersCommand.ts
@@ -1,6 +1,7 @@
 import AbstractCommand from '../AbstractCommand'
 import { AtemState } from '../../state'
 import { SuperSourceBox } from '../../state/video'
+import { Util } from '../..'
 
 export class SuperSourceBoxParametersCommand extends AbstractCommand {
 	static MaskFlags = {
@@ -29,14 +30,14 @@ export class SuperSourceBoxParametersCommand extends AbstractCommand {
 		this.properties = {
 			enabled: rawCommand[1] === 1,
 			source: rawCommand.readUInt16BE(2),
-			x: rawCommand.readInt16BE(4),
-			y: rawCommand.readInt16BE(6),
-			size: rawCommand.readUInt16BE(8),
+			x: Util.parseNumberBetween(rawCommand.readInt16BE(4), -4800, 4800),
+			y: Util.parseNumberBetween(rawCommand.readInt16BE(6), -3400, 3400),
+			size: Util.parseNumberBetween(rawCommand.readUInt16BE(8), 70, 1000),
 			cropped: rawCommand[10] === 1,
-			cropTop: rawCommand.readUInt16BE(12),
-			cropBottom: rawCommand.readUInt16BE(14),
-			cropLeft: rawCommand.readUInt16BE(16),
-			cropRight: rawCommand.readUInt16BE(18)
+			cropTop: Util.parseNumberBetween(rawCommand.readUInt16BE(12), 0, 18000),
+			cropBottom: Util.parseNumberBetween(rawCommand.readUInt16BE(14), 0, 18000),
+			cropLeft: Util.parseNumberBetween(rawCommand.readUInt16BE(16), 0, 32000),
+			cropRight: Util.parseNumberBetween(rawCommand.readUInt16BE(18), 0, 3200)
 		}
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,9 +3,11 @@ export * from './state'
 
 import * as Enums from './enums'
 import * as Commands from './commands'
+import { Util } from './lib/atemUtil'
 export {
 	Enums,
-	Commands
+	Commands,
+	Util
 }
 
 import * as VideoState from './state/video'

--- a/src/lib/atemSocket.ts
+++ b/src/lib/atemSocket.ts
@@ -12,7 +12,7 @@ export class AtemSocket extends EventEmitter {
 	private _retransmitTimer: NodeJS.Timer | undefined
 
 	private _localPacketId = 1
-	private _maxPacketID = 1 << 15 // Atem expects 15 not 16 bits before wrapping
+	private _maxPacketID = (1 << 15) - 1 // Atem expects 15 not 16 bits before wrapping
 	private _sessionId: number
 
 	private _address: string

--- a/src/lib/atemSocket.ts
+++ b/src/lib/atemSocket.ts
@@ -186,9 +186,13 @@ export class AtemSocket extends EventEmitter {
 		// this.log('COMMAND', `${name}(${length})`, buffer.slice(0, length))
 		const cmd = this._commandParser.commandFromRawName(name)
 		if (cmd && typeof cmd.deserialize === 'function') {
-			cmd.deserialize(buffer.slice(0, length).slice(8))
-			cmd.packetId = packetId || -1
-			this.emit('receivedStateChange', cmd)
+			try {
+				cmd.deserialize(buffer.slice(0, length).slice(8))
+				cmd.packetId = packetId || -1
+				this.emit('receivedStateChange', cmd)
+			} catch (e) {
+				this.emit('error', e)
+			}
 		}
 
 		if (buffer.length > length) {

--- a/src/lib/atemUtil.ts
+++ b/src/lib/atemUtil.ts
@@ -13,6 +13,17 @@ export namespace Util {
 		return slice.toString('ascii', 0, nullIndex < 0 ? slice.length : nullIndex)
 	}
 
+	export function parseNumberBetween (num: number, min: number, max: number): number {
+		if (num > max) throw Error('Number too big')
+		else if (num < min) throw Error('Number too small')
+		return num
+	}
+
+	export function parseEnum<G> (value: G, type: any): G {
+		if (!type[value]) throw Error('Value is not a valid option in enum')
+		return value
+	}
+
 	export const COMMAND_CONNECT_HELLO = Buffer.from([
 		0x10, 0x14, 0x53, 0xAB,
 		0x00, 0x00, 0x00, 0x00,

--- a/src/lib/atemUtil.ts
+++ b/src/lib/atemUtil.ts
@@ -14,8 +14,8 @@ export namespace Util {
 	}
 
 	export function parseNumberBetween (num: number, min: number, max: number): number {
-		if (num > max) throw Error('Number too big')
-		else if (num < min) throw Error('Number too small')
+		if (num > max) throw Error(`Number too big: ${num} > ${max}`)
+		else if (num < min) throw Error(`Number too small: ${num} < ${min}`)
 		return num
 	}
 

--- a/src/state/video/index.ts
+++ b/src/state/video/index.ts
@@ -80,7 +80,7 @@ export interface IMixEffect {
 	numberOfKeyers: number
 	transitionProperties: TransitionProperties
 	transitionSettings: TransitionSettings,
-	upstreamKeyers: Array<USK.UpstreamKeyer>
+	upstreamKeyers: { [index: number]: USK.UpstreamKeyer }
 }
 
 export class MixEffect implements IMixEffect {
@@ -95,7 +95,7 @@ export class MixEffect implements IMixEffect {
 	numberOfKeyers: number
 	transitionProperties: TransitionProperties = {} as TransitionProperties
 	transitionSettings: TransitionSettings = {} as TransitionSettings
-	upstreamKeyers: Array<USK.UpstreamKeyer> = []
+	upstreamKeyers: { [index: number]: USK.UpstreamKeyer } = []
 
 	constructor (index: number) {
 		this.index = index
@@ -108,7 +108,7 @@ export class MixEffect implements IMixEffect {
 				chromaSettings: {} as USK.UpstreamKeyerChromaSettings,
 				lumaSettings: {} as USK.UpstreamKeyerLumaSettings,
 				patternSettings: {} as USK.UpstreamKeyerPatternSettings,
-				flyKeyframes: [] as Array<USK.UpstreamKeyerFlyKeyframe>,
+				flyKeyframes: [] as { [index: number]: USK.UpstreamKeyerFlyKeyframe },
 				flyProperties: {} as USK.UpstreamKeyerFlySettings
 			} as USK.UpstreamKeyer
 		}
@@ -131,10 +131,10 @@ export interface SuperSourceBox {
 }
 
 export class AtemVideoState {
-	ME: Array<MixEffect> = []
-	downstreamKeyers: Array<DownstreamKeyer> = []
-	auxilliaries: Array<number> = []
-	superSourceBoxes: Array<SuperSourceBox> = []
+	ME: { [index: string]: MixEffect } = {}
+	downstreamKeyers: { [index: string]: DownstreamKeyer } = {}
+	auxilliaries: { [index: string]: number } = {}
+	superSourceBoxes: { [index: string]: SuperSourceBox } = {}
 
 	getMe (index: number) {
 		if (!this.ME[index]) {


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
This PR implements a method to validate if a value sent by the atem is an expected value. 


* **What is the current behavior?**
https://github.com/nrkno/tv-automation-atem-connection/issues/15
Invalid data is used as if its a valid value. This might cause undefined behaviour such as a 73rd mix effect being added.


* **What is the new behavior (if this is a feature change)?**
Values that are not inside the specified input range or a valid value from an enum will emit an error and the command will not be applied to the state.