### PR TITLE
feat: Use device ModelId to determine how many psu to track in state

### DIFF
--- a/src/commands/DeviceProfile/productIdentifierCommand.ts
+++ b/src/commands/DeviceProfile/productIdentifierCommand.ts
@@ -32,5 +32,17 @@ export class ProductIdentifierCommand extends AbstractCommand {
 	applyToState (state: AtemState) {
 		state.info.productIdentifier = this.properties.deviceName
 		state.info.model = this.properties.model
+
+		// Model specific features that aren't specified by the protocol
+		switch (state.info.model) {
+			case Enums.Model.TwoME:
+			case Enums.Model.TwoME4K:
+			case Enums.Model.TwoMEBS4K:
+				state.info.power = [false, false]
+				break
+			default:
+				state.info.power = [false]
+				break
+		}
 	}
 }

--- a/src/commands/PowerStatusCommand.ts
+++ b/src/commands/PowerStatusCommand.ts
@@ -4,21 +4,17 @@ import { AtemState } from '../state'
 export class PowerStatusCommand extends AbstractCommand {
 	rawName = 'Powr'
 
-	properties: {
-		pin1: boolean
-		pin2: boolean
-	}
+	properties: boolean[]
 
 	deserialize (rawCommand: Buffer) {
-		this.properties = {
-			pin1: Boolean(rawCommand[0] & 1 << 0),
-			pin2: Boolean(rawCommand[0] & 1 << 1)
-		}
+		this.properties = [
+			Boolean(rawCommand[0] & 1 << 0),
+			Boolean(rawCommand[0] & 1 << 1)
+		]
 	}
 
 	applyToState (state: AtemState) {
-		state.info.power = {
-			...this.properties
-		}
+		const count = state.info.power.length
+		state.info.power = this.properties.slice(0, count)
 	}
 }

--- a/src/commands/PowerStatusCommand.ts
+++ b/src/commands/PowerStatusCommand.ts
@@ -1,6 +1,11 @@
 import AbstractCommand from './AbstractCommand'
 import { AtemState } from '../state'
 
+/**
+ * This command gets the power status from the Atem. As defined in
+ * DeviceProfile/productIdentifierCommand.ts the 2ME, 2ME 4K and the
+ * Broadcast Studio have 2 power supplies. All other models have 1.
+ */
 export class PowerStatusCommand extends AbstractCommand {
 	rawName = 'Powr'
 

--- a/src/state/info.ts
+++ b/src/state/info.ts
@@ -19,16 +19,11 @@ export interface AtemCapabilites {
 	readonly hasSuperSources: boolean
 }
 
-export interface PowerStatus {
-	readonly pin1: boolean
-	readonly pin2: boolean
-}
-
 export class DeviceInfo {
 	apiVersion: VersionProps
 	capabilities: AtemCapabilites
 	model: Model
 	productIdentifier: string
 	superSourceBoxes: number
-	power: PowerStatus
+	power: boolean[]
 }


### PR DESCRIPTION
I can't find anything in TopologyCommand that could indicate the number of psu the device has, so have had to go with a mapping from ModelId.

state.info.power will be an array with length matching the number of psu, so library consumers can rely on this length as the count of psu.
