### PR TITLE
feat: Rename downstreamKeyId to downstreamKeyerId to make them all consistent

### DIFF
--- a/src/atem.ts
+++ b/src/atem.ts
@@ -119,7 +119,7 @@ export class Atem extends EventEmitter {
 
 	autoDownstreamKey (key = 0) {
 		const command = new Commands.DownstreamKeyAutoCommand()
-		command.downstreamKeyId = key
+		command.downstreamKeyerId = key
 		return this.sendCommand(command)
 	}
 
@@ -188,14 +188,14 @@ export class Atem extends EventEmitter {
 
 	setDownstreamKeyTie (tie: boolean, key = 0) {
 		const command = new Commands.DownstreamKeyTieCommand()
-		command.downstreamKeyId = key
+		command.downstreamKeyerId = key
 		command.updateProps({tie})
 		return this.sendCommand(command)
 	}
 
 	setDownstreamKeyOnAir (onAir: boolean, key = 0) {
 		const command = new Commands.DownstreamKeyOnAirCommand()
-		command.downstreamKeyId = key
+		command.downstreamKeyerId = key
 		command.updateProps({onAir})
 		return this.sendCommand(command)
 	}

--- a/src/commands/DownstreamKey/DownstreamKeyAutoCommand.ts
+++ b/src/commands/DownstreamKey/DownstreamKeyAutoCommand.ts
@@ -2,7 +2,7 @@ import AbstractCommand from '../AbstractCommand'
 
 export class DownstreamKeyAutoCommand extends AbstractCommand {
 	rawName = 'DDsA'
-	downstreamKeyId: number
+	downstreamKeyerId: number
 
 	properties: null
 
@@ -14,7 +14,7 @@ export class DownstreamKeyAutoCommand extends AbstractCommand {
 		const rawCommand = 'DDsA'
 		return new Buffer([
 			...Buffer.from(rawCommand),
-			this.downstreamKeyId,
+			this.downstreamKeyerId,
 			0x00, 0x00, 0x00
 		])
 	}

--- a/src/commands/DownstreamKey/DownstreamKeyOnAirCommand.ts
+++ b/src/commands/DownstreamKey/DownstreamKeyOnAirCommand.ts
@@ -2,7 +2,7 @@ import AbstractCommand from '../AbstractCommand'
 
 export class DownstreamKeyOnAirCommand extends AbstractCommand {
 	rawName = 'CDsL'
-	downstreamKeyId: number
+	downstreamKeyerId: number
 
 	properties: {
 		onAir: boolean
@@ -16,7 +16,7 @@ export class DownstreamKeyOnAirCommand extends AbstractCommand {
 		const rawCommand = 'CDsL'
 		return new Buffer([
 			...Buffer.from(rawCommand),
-			this.downstreamKeyId,
+			this.downstreamKeyerId,
 			this.properties.onAir,
 			0x00, 0x00
 		])

--- a/src/commands/DownstreamKey/DownstreamKeyStateCommand.ts
+++ b/src/commands/DownstreamKey/DownstreamKeyStateCommand.ts
@@ -5,12 +5,12 @@ import { Util } from '../..'
 
 export class DownstreamKeyStateCommand extends AbstractCommand {
 	rawName = 'DskS'
-	downstreamKeyId: number
+	downstreamKeyerId: number
 
 	properties: DownstreamKeyerBase
 
 	deserialize (rawCommand: Buffer) {
-		this.downstreamKeyId = Util.parseNumberBetween(rawCommand[0], 0, 3)
+		this.downstreamKeyerId = Util.parseNumberBetween(rawCommand[0], 0, 3)
 		this.properties = {
 			onAir: rawCommand[1] === 1,
 			inTransition: rawCommand[2] === 1,
@@ -27,8 +27,8 @@ export class DownstreamKeyStateCommand extends AbstractCommand {
 	}
 
 	applyToState (state: AtemState) {
-		state.video.downstreamKeyers[this.downstreamKeyId] = {
-			...state.video.downstreamKeyers[this.downstreamKeyId],
+		state.video.downstreamKeyers[this.downstreamKeyerId] = {
+			...state.video.downstreamKeyers[this.downstreamKeyerId],
 			...this.properties
 		}
 	}

--- a/src/commands/DownstreamKey/DownstreamKeyTieCommand.ts
+++ b/src/commands/DownstreamKey/DownstreamKeyTieCommand.ts
@@ -2,7 +2,7 @@ import AbstractCommand from '../AbstractCommand'
 
 export class DownstreamKeyTieCommand extends AbstractCommand {
 	rawName = 'CDsT'
-	downstreamKeyId: number
+	downstreamKeyerId: number
 
 	properties: {
 		tie: boolean
@@ -16,7 +16,7 @@ export class DownstreamKeyTieCommand extends AbstractCommand {
 		const rawCommand = 'CDsT'
 		return new Buffer([
 			...Buffer.from(rawCommand),
-			this.downstreamKeyId,
+			this.downstreamKeyerId,
 			this.properties.tie,
 			0x00, 0x00
 		])

--- a/src/commands/InitCompleteCommand.ts
+++ b/src/commands/InitCompleteCommand.ts
@@ -2,7 +2,6 @@ import AbstractCommand from './AbstractCommand'
 
 export class InitCompleteCommand extends AbstractCommand {
 	rawName = 'InCm'
-	downstreamKeyId: number
 	properties: null
 
 	deserialize () {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This is a breaking change. Renaming some command properties to be consistent.
It could impact any user who is interacting with the command classes, instead of the wrapper on the socket.

@baltedewit Once this is merged we will need to update tsr/atem-state to use the correct ids
