### PR TITLE
fixed super source box parameters (Crop Right can be 32000, not 3200)

### DIFF
--- a/src/commands/SuperSource/SuperSourceBoxParametersCommand.ts
+++ b/src/commands/SuperSource/SuperSourceBoxParametersCommand.ts
@@ -37,7 +37,7 @@ export class SuperSourceBoxParametersCommand extends AbstractCommand {
 			cropTop: Util.parseNumberBetween(rawCommand.readUInt16BE(12), 0, 18000),
 			cropBottom: Util.parseNumberBetween(rawCommand.readUInt16BE(14), 0, 18000),
 			cropLeft: Util.parseNumberBetween(rawCommand.readUInt16BE(16), 0, 32000),
-			cropRight: Util.parseNumberBetween(rawCommand.readUInt16BE(18), 0, 3200)
+			cropRight: Util.parseNumberBetween(rawCommand.readUInt16BE(18), 0, 32000)
 		}
 	}
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix


* **What is the current behavior?** (You can also link to an open issue here)
The library keeps throwing exceptions because of invalid super source range

It's documented in the unofficial ATEM-Protocol documentation: https://www.skaarhoj.com/fileadmin/BMDPROTOCOL.html under 'SSBP'. The range can be von 0 to 32000