### PR TITLE
Bugfix in audio mixer + added Master Channel

### DIFF
--- a/src/atem.ts
+++ b/src/atem.ts
@@ -22,7 +22,7 @@ import { DownstreamKeyerGeneral, DownstreamKeyerMask } from './state/video/downs
 import * as DT from './dataTransfer'
 import { Util } from './lib/atemUtil'
 import * as Enums from './enums'
-import { AudioChannel } from './state/audio'
+import { AudioChannel, AudioMasterChannel } from './state/audio'
 
 export interface AtemOptions {
 	address?: string,
@@ -457,6 +457,25 @@ export class Atem extends EventEmitter {
 	setAudioMixerInputBalance (index: number, balance: number) {
 		const command = new Commands.AudioMixerInputCommand()
 		command.index = index
+		command.updateProps({ balance })
+		return this.sendCommand(command)
+	}
+
+	setAudioMixerInputProps (index: number, props: Partial<AudioChannel>) {
+		const command = new Commands.AudioMixerInputCommand()
+		command.index = index
+		command.updateProps(props)
+		return this.sendCommand(command)
+	}
+
+	setAudioMixerMasterGain (gain: number) {
+		const command = new Commands.AudioMixerMasterCommand()
+		command.updateProps({ gain })
+		return this.sendCommand(command)
+	}
+
+	setAudioMixerMasterProps (props: Partial<AudioMasterChannel>) {
+		const command = new Commands.AudioMixerMasterCommand()
 		command.updateProps(props)
 		return this.sendCommand(command)
 	}

--- a/src/atem.ts
+++ b/src/atem.ts
@@ -440,21 +440,21 @@ export class Atem extends EventEmitter {
 		)
 	}
 
-	setAudioChannelMixOption (index: number, mixOption: Enums.AudioMixOption) {
+	setAudioMixerInputMixOption (index: number, mixOption: Enums.AudioMixOption) {
 		const command = new Commands.AudioMixerInputCommand()
 		command.index = index
 		command.updateProps({ mixOption })
 		return this.sendCommand(command)
 	}
 
-	setAudioChannelGain (index: number, gain: number) {
+	setAudioMixerInputGain (index: number, gain: number) {
 		const command = new Commands.AudioMixerInputCommand()
 		command.index = index
 		command.updateProps({ gain })
 		return this.sendCommand(command)
 	}
 
-	setAudioChannelProps (index: number, props: Partial<AudioChannel>) {
+	setAudioMixerInputBalance (index: number, balance: number) {
 		const command = new Commands.AudioMixerInputCommand()
 		command.index = index
 		command.updateProps(props)

--- a/src/commands/Audio/AudioMixerInputCommand.ts
+++ b/src/commands/Audio/AudioMixerInputCommand.ts
@@ -21,7 +21,7 @@ export class AudioMixerInputCommand extends AbstractCommand {
 			sourceType: rawCommand.readInt8(2),
 			portType: rawCommand.readInt8(7),
 			mixOption: rawCommand.readInt8(8),
-			gain: Util.UIntToDecibel(rawCommand.readUInt16BE(10)),
+			gain: Util.UInt16BEToDecibel(rawCommand.readUInt16BE(10)),
 			balance: Util.IntToBalance(rawCommand.readInt16BE(12))
 		}
 	}
@@ -31,7 +31,7 @@ export class AudioMixerInputCommand extends AbstractCommand {
 		buffer.writeUInt8(this.flag, 0)
 		buffer.writeUInt16BE(this.index, 2)
 		buffer.writeUInt8(this.properties.mixOption || 0, 4)
-		buffer.writeUInt16BE(Util.DecibelToUint(this.properties.gain || 0), 6)
+		buffer.writeUInt16BE(Util.DecibelToUInt16BE(this.properties.gain || 0), 6)
 		buffer.writeInt16BE(Util.BalanceToInt(this.properties.balance || 0), 8)
 
 		return Buffer.concat([

--- a/src/commands/Audio/AudioMixerInputCommand.ts
+++ b/src/commands/Audio/AudioMixerInputCommand.ts
@@ -22,7 +22,7 @@ export class AudioMixerInputCommand extends AbstractCommand {
 			portType: rawCommand.readInt8(7),
 			mixOption: rawCommand.readInt8(8),
 			gain: Util.UIntToDecibel(rawCommand.readUInt16BE(10)),
-			balance: rawCommand.readInt16BE(12)
+			balance: Util.IntToBalance(rawCommand.readInt16BE(12))
 		}
 	}
 
@@ -31,8 +31,9 @@ export class AudioMixerInputCommand extends AbstractCommand {
 		buffer.writeUInt8(this.flag, 0)
 		buffer.writeUInt16BE(this.index, 2)
 		buffer.writeUInt8(this.properties.mixOption || 0, 4)
-		buffer.writeUInt8(Util.DecibelToUint(this.properties.gain || 0), 8)
-		buffer.writeInt16BE(this.properties.balance || 0, 8)
+		buffer.writeUInt16BE(Util.DecibelToUint(this.properties.gain || 0), 6)
+		buffer.writeInt16BE(Util.BalanceToInt(this.properties.balance || 0), 8)
+
 		return Buffer.concat([
 			Buffer.from('CAMI', 'ascii'),
 			buffer

--- a/src/commands/Audio/AudioMixerMasterCommand.ts
+++ b/src/commands/Audio/AudioMixerMasterCommand.ts
@@ -1,0 +1,43 @@
+import AbstractCommand from '../AbstractCommand'
+import { AtemState } from '../../state'
+import { Util } from '../..'
+import { AudioMasterChannel } from '../../state/audio'
+
+export class AudioMixerMasterCommand extends AbstractCommand {
+	static MaskFlags = {
+		gain: 1 << 0,
+		balance: 1 << 1,
+		followFadeToBlack: 1 << 2
+	}
+	rawName = 'AMMO'
+
+	properties: Partial<AudioMasterChannel>
+
+	deserialize (rawCommand: Buffer) {
+		this.properties = {
+			gain: Util.UIntToDecibel(rawCommand.readUInt16BE(0)),
+			balance: Util.IntToBalance(rawCommand.readInt16BE(2)),
+			followFadeToBlack: rawCommand.readInt8(4) === 1
+		}
+	}
+
+	serialize () {
+		const buffer = Buffer.alloc(8)
+		buffer.writeUInt8(1, 0)
+		buffer.writeUInt16BE(Util.DecibelToUint(this.properties.gain || 0), 2)
+		buffer.writeInt16BE(Util.BalanceToInt(this.properties.balance || 0), 4)
+		buffer.writeUInt8(this.properties.followFadeToBlack ? 0x01 : 0x00 , 6) // Note: I never got this one to work
+
+		return Buffer.concat([
+			Buffer.from('CAMM', 'ascii'),
+			buffer
+		])
+	}
+
+	applyToState (state: AtemState) {
+		state.audio.master = {
+			...state.audio.master,
+			...this.properties
+		}
+	}
+}

--- a/src/commands/Audio/AudioMixerMasterCommand.ts
+++ b/src/commands/Audio/AudioMixerMasterCommand.ts
@@ -15,7 +15,7 @@ export class AudioMixerMasterCommand extends AbstractCommand {
 
 	deserialize (rawCommand: Buffer) {
 		this.properties = {
-			gain: Util.UIntToDecibel(rawCommand.readUInt16BE(0)),
+			gain: Util.UInt16BEToDecibel(rawCommand.readUInt16BE(0)),
 			balance: Util.IntToBalance(rawCommand.readInt16BE(2)),
 			followFadeToBlack: rawCommand.readInt8(4) === 1
 		}
@@ -24,7 +24,7 @@ export class AudioMixerMasterCommand extends AbstractCommand {
 	serialize () {
 		const buffer = Buffer.alloc(8)
 		buffer.writeUInt8(1, 0)
-		buffer.writeUInt16BE(Util.DecibelToUint(this.properties.gain || 0), 2)
+		buffer.writeUInt16BE(Util.DecibelToUInt16BE(this.properties.gain || 0), 2)
 		buffer.writeInt16BE(Util.BalanceToInt(this.properties.balance || 0), 4)
 		buffer.writeUInt8(this.properties.followFadeToBlack ? 0x01 : 0x00 , 6) // Note: I never got this one to work
 

--- a/src/commands/Audio/AudioMixerMasterCommand.ts
+++ b/src/commands/Audio/AudioMixerMasterCommand.ts
@@ -23,7 +23,7 @@ export class AudioMixerMasterCommand extends AbstractCommand {
 
 	serialize () {
 		const buffer = Buffer.alloc(8)
-		buffer.writeUInt8(1, 0)
+		buffer.writeUInt8(this.flag, 0)
 		buffer.writeUInt16BE(Util.DecibelToUInt16BE(this.properties.gain || 0), 2)
 		buffer.writeInt16BE(Util.BalanceToInt(this.properties.balance || 0), 4)
 		buffer.writeUInt8(this.properties.followFadeToBlack ? 0x01 : 0x00 , 6) // Note: I never got this one to work

--- a/src/commands/Audio/index.ts
+++ b/src/commands/Audio/index.ts
@@ -1,1 +1,2 @@
 export * from './AudioMixerInputCommand'
+export * from './AudioMixerMasterCommand'

--- a/src/enums/index.ts
+++ b/src/enums/index.ts
@@ -261,9 +261,9 @@ export enum MultiViewerLayout {
 }
 
 export enum AudioMixOption {
-	Off,
-	On,
-	AudioFollowVideo
+	Off = 0,
+	On = 1,
+	AudioFollowVideo = 2
 }
 
 export enum AudioSourceType {

--- a/src/lib/atemUtil.ts
+++ b/src/lib/atemUtil.ts
@@ -201,18 +201,18 @@ export namespace Util {
 		return buffer2
 	}
 
-	export function UIntToDecibel (input: number) {
+	export function UInt16BEToDecibel (input: number) {
 		// 0 = -inf, 32768 = 0, 65381 = +6db
 		return Math.round((Math.log10(input / 32768) * 20) * 100) / 100
 	}
 
-	export function DecibelToUint (input: number) {
+	export function DecibelToUInt16BE (input: number) {
 		return parseInt(Math.pow(10, input / 20) * 32768 + '', 10)
 	}
 
 	export function IntToBalance (input: number): number {
 		// -100000 = -50, 0x0000 = 0, 0x2710 = +50
-		return Math.round((input / 200) * 10) /10
+		return Math.round((input / 200) * 10) / 10
 	}
 	export function BalanceToInt (input: number): number {
 		return Math.round(input * 200)

--- a/src/lib/atemUtil.ts
+++ b/src/lib/atemUtil.ts
@@ -202,10 +202,19 @@ export namespace Util {
 	}
 
 	export function UIntToDecibel (input: number) {
-		return Math.log10(input / 128) * 20
+		// 0 = -inf, 32768 = 0, 65381 = +6db
+		return Math.round((Math.log10(input / 32768) * 20) * 100) / 100
 	}
 
 	export function DecibelToUint (input: number) {
-		return parseInt(Math.pow(10, input / 20) * 128 + '', 10)
+		return parseInt(Math.pow(10, input / 20) * 32768 + '', 10)
+	}
+
+	export function IntToBalance (input: number): number {
+		// -100000 = -50, 0x0000 = 0, 0x2710 = +50
+		return Math.round((input / 200) * 10) /10
+	}
+	export function BalanceToInt (input: number): number {
+		return Math.round(input * 200)
 	}
 }

--- a/src/state/audio.ts
+++ b/src/state/audio.ts
@@ -10,11 +10,19 @@ export class AudioChannel {
 	balance: number
 }
 
+export class AudioMasterChannel {
+	/** Gain in decibel, -Infinity to +6dB */
+	gain: number
+	/** Balance, -50 to +50 */
+	balance: number
+	followFadeToBlack: boolean
+}
+
 export class AtemAudioState {
 	numberOfChannels: number
 	hasMonitor: boolean
 	channels: Array<AudioChannel> = []
-	master: AudioChannel = new AudioChannel()
+	master: AudioMasterChannel = new AudioMasterChannel()
 
 	getChannel (index: number) {
 		if (!this.channels[index]) {

--- a/src/state/audio.ts
+++ b/src/state/audio.ts
@@ -4,7 +4,9 @@ export class AudioChannel {
 	sourceType: AudioSourceType
 	portType: ExternalPortType
 	mixOption: AudioMixOption
+	/** Gain in decibel, -Infinity to +6dB */
 	gain: number
+	/** Balance, -50 to +50 */
 	balance: number
 }
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix: Handling of audio channels data
Feature: Add support for Master Channel

Breaking change: I renamed the `setAudioChannelXX` methods to `setAudioMixerInputXXX` so that they will better harmonize with the other audio commands (Input, Master, Monitor (not implemented yet) etc..)
