### PR TITLE
- fixed wrong number. borderHue can be a number between 0 and 3599.

### DIFF
--- a/src/commands/MixEffects/Key/MixEffectKeyFlyKeyframeGetCommand.ts
+++ b/src/commands/MixEffects/Key/MixEffectKeyFlyKeyframeGetCommand.ts
@@ -29,7 +29,7 @@ export class MixEffectKeyFlyKeyframeGetCommand extends AbstractCommand {
 			borderBevelPosition: Util.parseNumberBetween(rawCommand.readInt8(31), 0, 100),
 
 			borderOpacity: Util.parseNumberBetween(rawCommand.readInt8(32), 0, 100),
-			borderHue: Util.parseNumberBetween(rawCommand.readUInt16BE(34), 0, 1000),
+			borderHue: Util.parseNumberBetween(rawCommand.readUInt16BE(34), 0, 3599),
 			borderSaturation: Util.parseNumberBetween(rawCommand.readUInt16BE(36), 0, 1000),
 			borderLuma: Util.parseNumberBetween(rawCommand.readUInt16BE(38), 0, 1000),
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
fixed the wrong check of Border Hue inside the Protocol


* **What is the current behavior?** (You can also link to an open issue here)
The Applications crashes on wrong value


* **What is the new behavior (if this is a feature change)?**
It uses now the correct value


* **Other information**:
see 'KeDV' in https://www.skaarhoj.com/fileadmin/BMDPROTOCOL.html