### PR TITLE
WIP: serializing commands without update props

### DIFF
--- a/src/commands/__tests__/index.spec.ts
+++ b/src/commands/__tests__/index.spec.ts
@@ -831,3 +831,19 @@ describe('Commands v7.2', () => {
 		runTestForCommand(commandParser, commandConverters, i, testCase, true)
 	}
 })
+
+describe('Serialize with no properties', () => {
+	const commandParser = new CommandParser()
+	commandParser.version = ProtocolVersion.V7_2
+
+	for (const name of Object.keys(commandParser.commands)) {
+		for (const cmd of commandParser.commands[name]) {
+			test(`Test  ${name}`, () => {
+				const inst = new cmd()
+				if (inst.serialize) {
+					expect(inst.serialize(commandParser.version)).toBeTruthy()
+				}
+			})
+		}
+	}
+})


### PR DESCRIPTION
@baltedewit Something for one of us to look into sometime.
This would be a better fix for `autoDownstreamKey()` than 71c61f66529168615e99622da32ebc14e17c4918