### PR TITLE
Extract audio bitrates from SRSU

### DIFF
--- a/src/commands/Streaming/StreamingServiceCommand.ts
+++ b/src/commands/Streaming/StreamingServiceCommand.ts
@@ -43,6 +43,7 @@ export class StreamingServiceUpdateCommand extends DeserializedCommand<Streaming
 			url: bufToNullTerminatedString(rawCommand, 64, 512),
 			key: bufToNullTerminatedString(rawCommand, 576, 512),
 			bitrates: [rawCommand.readUInt32BE(1088), rawCommand.readUInt32BE(1092)],
+			audioBitrates: [rawCommand.readUInt32BE(1104), rawCommand.readUInt32BE(1108)],
 		}
 
 		return new StreamingServiceUpdateCommand(props)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds extract of stream audio bitrates, alongside existing extract of video bitrates


* **What is the current behavior?** (You can also link to an open issue here)
Audio bitrates are not extracted



* **What is the new behavior (if this is a feature change)?**
Audio bitrates are extracted


* **Other information**:

A test across a wireshark-captured SRSU packet, where the stream AV settings xml are known to be 6mbit and 128kbit, returns:
```
node readSRSU.js
SRSU.hex
<Buffer 46 42 43 4c 69 76 65 00 00 00 00 00 00 50 72 70 00 00 00 00 00 00 00 00 00 20 43 50 43 43 64 50 07 01 05 03 00 00 00 00 00 01 00 00 00 50 72 70 00 00 ... 1306 more bytes>
{ from: 0, len: 64 }
{ serviceName: 'FBCLive' }
{ from: 64, len: 512 }
{ url: 'rtmps://a.rtmps.youtube.com/live2' }
{ from: 576, len: 512 }
{ key: 'p233-****-****-****-424h' }
{ from: 1088, len: 4 }
{ lowVideoBitrate: 6000000 }
{ from: 1092, len: 4 }
{ hiVideoBitrate: 6000000 }
{ from: 1104, len: 4 }
{ lowAudioBitrate: 128000 }
{ from: 1108, len: 4 }
{ hiAudioBitrate: 128000 }
```