### PR TITLE
feat: command batching SOFIE-2549

### DIFF
--- a/src/__tests__/atem.spec.ts
+++ b/src/__tests__/atem.spec.ts
@@ -131,7 +131,7 @@ describe('Atem', () => {
 			expect(socket.sendCommands).toHaveBeenCalledWith([cmd])
 
 			// Trigger the ack, and it should switfy resolve
-			socket.emit('commandsAck', [124])
+			socket.emit('ackPackets', [124])
 			expect(Object.keys(sentQueue)).toHaveLength(0)
 
 			// Finally, it should now resolve without a timeout

--- a/src/__tests__/atem.spec.ts
+++ b/src/__tests__/atem.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/unbound-method */
-import { Atem, DEFAULT_MTU, DEFAULT_PORT } from '../atem'
+import { Atem, DEFAULT_MAX_PACKET_SIZE, DEFAULT_PORT } from '../atem'
 import { CutCommand } from '../commands'
 import { promisify } from 'util'
 import { EventEmitter } from 'events'
@@ -35,14 +35,14 @@ describe('Atem', () => {
 				disableMultithreaded: true,
 				log: (conn as any)._log,
 				port: DEFAULT_PORT,
-				packetMtu: DEFAULT_MTU,
+				maxPacketSize: DEFAULT_MAX_PACKET_SIZE,
 			})
 		} finally {
 			await conn.destroy()
 		}
 	})
 	test('constructor test 2', async () => {
-		const conn = new Atem({ debugBuffers: true, address: 'test1', port: 23, packetMtu: 500 })
+		const conn = new Atem({ debugBuffers: true, address: 'test1', port: 23, maxPacketSize: 500 })
 
 		try {
 			const socket = (conn as any).socket as AtemSocket
@@ -56,7 +56,7 @@ describe('Atem', () => {
 				disableMultithreaded: false,
 				log: (conn as any)._log,
 				port: 23,
-				packetMtu: 500,
+				maxPacketSize: 500,
 			})
 		} finally {
 			await conn.destroy()

--- a/src/__tests__/atem.spec.ts
+++ b/src/__tests__/atem.spec.ts
@@ -110,11 +110,11 @@ describe('Atem', () => {
 			expect(socket).toBeTruthy()
 
 			let nextId = 123
-			Object.defineProperty(socket, 'nextCommandTrackingId', {
+			Object.defineProperty(socket, 'nextPacketTrackingId', {
 				get: jest.fn(() => nextId++),
 				set: jest.fn(),
 			})
-			expect(socket.nextCommandTrackingId).toEqual(123)
+			expect(socket.nextPacketTrackingId).toEqual(123)
 
 			socket.sendCommands = jest.fn(() => Promise.resolve([124]) as any)
 
@@ -150,11 +150,11 @@ describe('Atem', () => {
 			expect(socket).toBeTruthy()
 
 			let nextId = 123
-			Object.defineProperty(socket, 'nextCommandTrackingId', {
+			Object.defineProperty(socket, 'nextPacketTrackingId', {
 				get: jest.fn(() => nextId++),
 				set: jest.fn(),
 			})
-			expect(socket.nextCommandTrackingId).toEqual(123)
+			expect(socket.nextPacketTrackingId).toEqual(123)
 
 			socket.sendCommands = jest.fn(() => Promise.reject(35) as any)
 

--- a/src/__tests__/connection.spec.ts
+++ b/src/__tests__/connection.spec.ts
@@ -18,18 +18,18 @@ class AtemSocketChildMock implements AtemSocketChild {
 	public onDisconnect: () => Promise<void>
 	public onLog: (message: string) => Promise<void>
 	public onCommandsReceived: (payload: Buffer, packetId: number) => Promise<void>
-	public onCommandsAcknowledged: (ids: Array<{ packetId: number; trackingId: number }>) => Promise<void>
+	public onPacketsAcknowledged: (ids: Array<{ packetId: number; trackingId: number }>) => Promise<void>
 
 	constructor(
 		onDisconnect: () => Promise<void>,
 		onLog: (message: string) => Promise<void>,
 		onCommandsReceived: (payload: Buffer, packetId: number) => Promise<void>,
-		onCommandsAcknowledged: (ids: Array<{ packetId: number; trackingId: number }>) => Promise<void>
+		onPacketsAcknowledged: (ids: Array<{ packetId: number; trackingId: number }>) => Promise<void>
 	) {
 		this.onDisconnect = onDisconnect
 		this.onLog = onLog
 		this.onCommandsReceived = onCommandsReceived
-		this.onCommandsAcknowledged = onCommandsAcknowledged
+		this.onPacketsAcknowledged = onPacketsAcknowledged
 	}
 
 	public connect = jest.fn(async () => Promise.resolve())
@@ -43,9 +43,9 @@ class AtemSocketChildMock implements AtemSocketChild {
 		onDisconnect: () => Promise<void>,
 		onLog: (message: string) => Promise<void>,
 		onCommandsReceived: (payload: Buffer, packetId: number) => Promise<void>,
-		onCommandsAcknowledged: (ids: Array<{ packetId: number; trackingId: number }>) => Promise<void>
+		onPacketsAcknowledged: (ids: Array<{ packetId: number; trackingId: number }>) => Promise<void>
 	) => {
-		return new AtemSocketChildMock(onDisconnect, onLog, onCommandsReceived, onCommandsAcknowledged)
+		return new AtemSocketChildMock(onDisconnect, onLog, onCommandsReceived, onPacketsAcknowledged)
 	}
 )
 

--- a/src/atem.ts
+++ b/src/atem.ts
@@ -59,6 +59,10 @@ export interface AtemOptions {
 	debugBuffers?: boolean
 	disableMultithreaded?: boolean
 	childProcessTimeout?: number
+	/**
+	 * Maximum size of packets to transmit
+	 */
+	packetMtu?: number
 }
 
 export type AtemEvents = {
@@ -86,6 +90,7 @@ export enum AtemConnectionStatus {
 }
 
 export const DEFAULT_PORT = 9910
+export const DEFAULT_MTU = 1500
 
 export class BasicAtem extends EventEmitter<AtemEvents> {
 	private readonly socket: AtemSocket
@@ -97,14 +102,16 @@ export class BasicAtem extends EventEmitter<AtemEvents> {
 	constructor(options?: AtemOptions) {
 		super()
 
+		// const packetMtu = options?.packetMtu ?? DEFAULT_MTU
+
 		this._state = AtemStateUtil.Create()
 		this._status = AtemConnectionStatus.CLOSED
 		this.socket = new AtemSocket({
-			debugBuffers: (options || {}).debugBuffers || false,
-			address: (options || {}).address || '',
-			port: (options || {}).port || DEFAULT_PORT,
-			disableMultithreaded: (options || {}).disableMultithreaded || false,
-			childProcessTimeout: (options || {}).childProcessTimeout || 600,
+			debugBuffers: options?.debugBuffers ?? false,
+			address: options?.address || '',
+			port: options?.port || DEFAULT_PORT,
+			disableMultithreaded: options?.disableMultithreaded ?? false,
+			childProcessTimeout: options?.childProcessTimeout || 600,
 		})
 		this.dataTransferManager = new DT.DataTransferManager(this.sendCommands.bind(this))
 

--- a/src/atem.ts
+++ b/src/atem.ts
@@ -62,7 +62,7 @@ export interface AtemOptions {
 	/**
 	 * Maximum size of packets to transmit
 	 */
-	packetMtu?: number
+	maxPacketSize?: number
 }
 
 export type AtemEvents = {
@@ -89,7 +89,7 @@ export enum AtemConnectionStatus {
 }
 
 export const DEFAULT_PORT = 9910
-export const DEFAULT_MTU = 1500
+export const DEFAULT_MAX_PACKET_SIZE = 1416 // Matching ATEM software
 
 export class BasicAtem extends EventEmitter<AtemEvents> {
 	private readonly socket: AtemSocket
@@ -109,7 +109,7 @@ export class BasicAtem extends EventEmitter<AtemEvents> {
 			port: options?.port || DEFAULT_PORT,
 			disableMultithreaded: options?.disableMultithreaded ?? false,
 			childProcessTimeout: options?.childProcessTimeout || 600,
-			packetMtu: options?.packetMtu ?? DEFAULT_MTU,
+			maxPacketSize: options?.maxPacketSize ?? DEFAULT_MAX_PACKET_SIZE,
 		})
 		this.dataTransferManager = new DT.DataTransferManager(this.sendCommands.bind(this))
 

--- a/src/atem.ts
+++ b/src/atem.ts
@@ -101,8 +101,6 @@ export class BasicAtem extends EventEmitter<AtemEvents> {
 	constructor(options?: AtemOptions) {
 		super()
 
-		// const packetMtu = options?.packetMtu ?? DEFAULT_MTU
-
 		this._state = AtemStateUtil.Create()
 		this._status = AtemConnectionStatus.CLOSED
 		this.socket = new AtemSocket({
@@ -111,6 +109,7 @@ export class BasicAtem extends EventEmitter<AtemEvents> {
 			port: options?.port || DEFAULT_PORT,
 			disableMultithreaded: options?.disableMultithreaded ?? false,
 			childProcessTimeout: options?.childProcessTimeout || 600,
+			packetMtu: options?.packetMtu ?? DEFAULT_MTU,
 		})
 		this.dataTransferManager = new DT.DataTransferManager(this.sendCommands.bind(this))
 

--- a/src/atem.ts
+++ b/src/atem.ts
@@ -113,11 +113,11 @@ export class BasicAtem extends EventEmitter<AtemEvents> {
 		})
 		this.dataTransferManager = new DT.DataTransferManager(this.sendCommands.bind(this))
 
-		this.socket.on('commandsReceived', (commands) => {
+		this.socket.on('receivedCommands', (commands) => {
 			this.emit('receivedCommands', commands)
 			this._mutateState(commands)
 		})
-		this.socket.on('commandsAck', (trackingIds) => this._resolveCommands(trackingIds))
+		this.socket.on('ackPackets', (trackingIds) => this._resolveCommands(trackingIds))
 		this.socket.on('info', (msg) => this.emit('info', msg))
 		this.socket.on('debug', (msg) => this.emit('debug', msg))
 		this.socket.on('error', (e) => this.emit('error', e))

--- a/src/dataTransfer/__tests__/index.spec.ts
+++ b/src/dataTransfer/__tests__/index.spec.ts
@@ -36,10 +36,10 @@ function mangleCommand(cmd: any, dir: string): any {
 }
 
 function runDataTransferTest(spec: any): DataTransferManager {
-	const manager = new DataTransferManager((cmds) =>
-		cmds.map(async (cmd) => {
+	const manager = new DataTransferManager(async (cmds) => {
+		for (const rawCmd of cmds) {
 			const expectedCmd = spec.shift()
-			const gotCmd = mangleCommand(cmd, 'send')
+			const gotCmd = mangleCommand(rawCmd, 'send')
 			expect(gotCmd).toEqual(expectedCmd)
 
 			while (spec.length > 0) {
@@ -49,10 +49,8 @@ function runDataTransferTest(spec: any): DataTransferManager {
 				if (!nextCmd2) throw new Error(`Failed specToCommandClass ${nextCmd.name}`)
 				manager.queueHandleCommand(nextCmd2)
 			}
-
-			return Promise.resolve()
-		})
-	)
+		}
+	})
 	manager.startCommandSending(true)
 	return manager
 }

--- a/src/dataTransfer/__tests__/upload-multiviewer-sequence.json
+++ b/src/dataTransfer/__tests__/upload-multiviewer-sequence.json
@@ -24,7 +24,7 @@
 		"properties": {
 			"name": "Label",
 			"description": "",
-			"fileHash": "T�9z�;{\u0012r����-��",
+			"fileHash": "VKA5etY7exJy9ayH+i3d4Q==",
 			"transferId": 0
 		},
 		"direction": "send"

--- a/src/dataTransfer/index.ts
+++ b/src/dataTransfer/index.ts
@@ -30,7 +30,7 @@ export class DataTransferManager {
 	}
 
 	readonly #sendLockCommand = (/*lock: DataTransferLockingQueue,*/ cmd: ISerializableCommand): void => {
-		Promise.all(this.#rawSendCommands([cmd])).catch((e) => {
+		this.#rawSendCommands([cmd]).catch((e) => {
 			debug(`Failed to send lock command: ${e}`)
 			console.log('Failed to send lock command')
 		})
@@ -41,12 +41,12 @@ export class DataTransferManager {
 	readonly #labelsLock = new DataTransferSimpleQueue(this.#nextTransferId)
 	readonly #macroLock = new DataTransferSimpleQueue(this.#nextTransferId)
 
-	readonly #rawSendCommands: (cmds: ISerializableCommand[]) => Array<Promise<void>>
+	readonly #rawSendCommands: (cmds: ISerializableCommand[]) => Promise<void>
 
 	private interval?: NodeJS.Timer
 	private exitUnsubscribe?: () => void
 
-	constructor(rawSendCommands: (cmds: ISerializableCommand[]) => Array<Promise<void>>) {
+	constructor(rawSendCommands: (cmds: ISerializableCommand[]) => Promise<void>) {
 		this.#rawSendCommands = rawSendCommands
 	}
 
@@ -75,7 +75,7 @@ export class DataTransferManager {
 					const commandsToSend = lock.popQueuedCommands(MAX_PACKETS_TO_SEND_PER_TICK) // Take some, it is unlikely that multiple will run at once
 					if (commandsToSend && commandsToSend.length > 0) {
 						// debug(`Sending ${commandsToSend.length} commands `)
-						Promise.all(this.#rawSendCommands(commandsToSend)).catch((e) => {
+						this.#rawSendCommands(commandsToSend).catch((e) => {
 							// Failed to send/queue something, so abort it
 							lock.tryAbortTransfer(new Error(`Command send failed: ${e}`))
 						})

--- a/src/lib/__tests__/atemSocket.spec.ts
+++ b/src/lib/__tests__/atemSocket.spec.ts
@@ -108,7 +108,7 @@ describe('AtemSocket', () => {
 			port: 890,
 			disableMultithreaded: true,
 			childProcessTimeout: 100,
-			packetMtu: 1500,
+			maxPacketSize: 1416,
 		})
 	}
 

--- a/src/lib/__tests__/atemSocket.spec.ts
+++ b/src/lib/__tests__/atemSocket.spec.ts
@@ -25,7 +25,7 @@ class AtemSocketChildMock implements AtemSocketChild {
 	public onDisconnect: () => Promise<void>
 	public onLog: (message: string) => Promise<void>
 	public onCommandsReceived: (payload: Buffer, packetId: number) => Promise<void>
-	public onCommandsAcknowledged: (ids: Array<{ packetId: number; trackingId: number }>) => Promise<void>
+	public onPacketsAcknowledged: (ids: Array<{ packetId: number; trackingId: number }>) => Promise<void>
 
 	constructor() {
 		// this._debug = options.debug
@@ -35,7 +35,7 @@ class AtemSocketChildMock implements AtemSocketChild {
 		this.onDisconnect = async (): Promise<void> => Promise.resolve()
 		this.onLog = async (msg): Promise<void> => console.log(msg)
 		this.onCommandsReceived = async (): Promise<void> => Promise.resolve()
-		this.onCommandsAcknowledged = async (): Promise<void> => Promise.resolve()
+		this.onPacketsAcknowledged = async (): Promise<void> => Promise.resolve()
 	}
 
 	public connect = jest.fn(async () => Promise.resolve())
@@ -50,12 +50,12 @@ const AtemSocketChildSingleton = new AtemSocketChildMock()
 		onDisconnect: () => Promise<void>,
 		onLog: (message: string) => Promise<void>,
 		onCommandsReceived: (payload: Buffer, packetId: number) => Promise<void>,
-		onCommandsAcknowledged: (ids: Array<{ packetId: number; trackingId: number }>) => Promise<void>
+		onPacketsAcknowledged: (ids: Array<{ packetId: number; trackingId: number }>) => Promise<void>
 	) => {
 		AtemSocketChildSingleton.onDisconnect = onDisconnect
 		AtemSocketChildSingleton.onLog = onLog
 		AtemSocketChildSingleton.onCommandsReceived = onCommandsReceived
-		AtemSocketChildSingleton.onCommandsAcknowledged = onCommandsAcknowledged
+		AtemSocketChildSingleton.onPacketsAcknowledged = onPacketsAcknowledged
 		return AtemSocketChildSingleton
 	}
 )
@@ -88,7 +88,7 @@ describe('AtemSocket', () => {
 		if (!lite) {
 			AtemSocketChildSingleton.onLog = async (): Promise<void> => Promise.resolve()
 			AtemSocketChildSingleton.onDisconnect = async (): Promise<void> => Promise.resolve()
-			AtemSocketChildSingleton.onCommandsAcknowledged = async (): Promise<void> => Promise.resolve()
+			AtemSocketChildSingleton.onPacketsAcknowledged = async (): Promise<void> => Promise.resolve()
 			AtemSocketChildSingleton.onCommandsReceived = async (): Promise<void> => Promise.resolve()
 		}
 	}
@@ -328,15 +328,15 @@ describe('AtemSocket', () => {
 		const ack = jest.fn()
 
 		socket.on('disconnect', disconnect)
-		socket.on('commandsAck', ack)
+		socket.on('ackPackets', ack)
 
 		expect(AtemSocketChildSingleton.onDisconnect).toBeDefined()
 		await AtemSocketChildSingleton.onDisconnect()
 		await clock.tickAsync(0)
 		expect(disconnect).toHaveBeenCalledTimes(1)
 
-		expect(AtemSocketChildSingleton.onCommandsAcknowledged).toBeDefined()
-		await AtemSocketChildSingleton.onCommandsAcknowledged([{ packetId: 675, trackingId: 98 }])
+		expect(AtemSocketChildSingleton.onPacketsAcknowledged).toBeDefined()
+		await AtemSocketChildSingleton.onPacketsAcknowledged([{ packetId: 675, trackingId: 98 }])
 		await clock.tickAsync(0)
 		expect(ack).toHaveBeenCalledTimes(1)
 		expect(ack).toHaveBeenCalledWith([98])
@@ -354,7 +354,7 @@ describe('AtemSocket', () => {
 		const change = jest.fn()
 
 		socket.on('error', error)
-		socket.on('commandsReceived', change)
+		socket.on('receivedCommands', change)
 
 		const parser = (socket as any)._commandParser as CommandParser
 		expect(parser).toBeTruthy()
@@ -383,7 +383,7 @@ describe('AtemSocket', () => {
 		const change = jest.fn()
 
 		socket.on('error', error)
-		socket.on('commandsReceived', change)
+		socket.on('receivedCommands', change)
 
 		const parser = (socket as any)._commandParser as CommandParser
 		expect(parser).toBeTruthy()
@@ -420,7 +420,7 @@ describe('AtemSocket', () => {
 		const change = jest.fn()
 
 		socket.on('error', error)
-		socket.on('commandsReceived', change)
+		socket.on('receivedCommands', change)
 
 		const parser = (socket as any)._commandParser as CommandParser
 		expect(parser).toBeTruthy()
@@ -479,7 +479,7 @@ describe('AtemSocket', () => {
 		const change = jest.fn()
 
 		socket.on('error', error)
-		socket.on('commandsReceived', change)
+		socket.on('receivedCommands', change)
 
 		const testBuffer = Buffer.alloc(0)
 		const pktId = 822
@@ -502,7 +502,7 @@ describe('AtemSocket', () => {
 		const change = jest.fn()
 
 		socket.on('error', error)
-		socket.on('commandsReceived', change)
+		socket.on('receivedCommands', change)
 
 		const testBuffer = Buffer.alloc(10, 0)
 		const pktId = 822
@@ -525,7 +525,7 @@ describe('AtemSocket', () => {
 		const change = jest.fn()
 
 		socket.on('error', error)
-		socket.on('commandsReceived', change)
+		socket.on('receivedCommands', change)
 
 		class BrokenCommand extends DeserializedCommand<{}> {
 			public static readonly rawName = 'TEST'

--- a/src/lib/__tests__/atemSocket.spec.ts
+++ b/src/lib/__tests__/atemSocket.spec.ts
@@ -198,12 +198,12 @@ describe('AtemSocket', () => {
 		expect(AtemSocketChildSingleton.connect).toHaveBeenCalledWith('new', 455)
 	})
 
-	test('nextCommandTrackingId', () => {
+	test('nextPacketTrackingId', () => {
 		const socket = createSocket()
 
-		expect(socket.nextCommandTrackingId).toEqual(1)
-		expect(socket.nextCommandTrackingId).toEqual(2)
-		expect(socket.nextCommandTrackingId).toEqual(3)
+		expect(socket.nextPacketTrackingId).toEqual(1)
+		expect(socket.nextPacketTrackingId).toEqual(2)
+		expect(socket.nextPacketTrackingId).toEqual(3)
 	})
 
 	test('disconnect', async () => {
@@ -293,7 +293,7 @@ describe('AtemSocket', () => {
 		}
 
 		const cmd = new MockCommand({})
-		;(socket as any)._nextCommandTrackingId = 835
+		;(socket as any)._nextPacketTrackingId = 835
 		await socket.sendCommands([cmd])
 
 		// connect was called explicitly

--- a/src/lib/__tests__/packetBuilder.spec.ts
+++ b/src/lib/__tests__/packetBuilder.spec.ts
@@ -1,0 +1,120 @@
+import type { ISerializableCommand } from '../../commands'
+import { ProtocolVersion } from '../../enums'
+import { PacketBuilder } from '../packetBuilder'
+
+class FakeCommand implements ISerializableCommand {
+	static readonly rawName: string = 'FAKE'
+
+	constructor(public readonly length: number, public readonly value: number = 1) {}
+
+	public get lengthWithHeader(): number {
+		return this.length + 8
+	}
+
+	serialize = jest.fn((_version: ProtocolVersion): Buffer => {
+		return Buffer.alloc(this.length, this.value)
+	})
+}
+
+describe('PacketBuilder', () => {
+	it('No commands', () => {
+		const builder = new PacketBuilder(500, ProtocolVersion.V8_1_1)
+		expect(builder.getPackets()).toHaveLength(0)
+	})
+
+	it('Single command', () => {
+		const builder = new PacketBuilder(500, ProtocolVersion.V8_1_1)
+
+		const cmd = new FakeCommand(10)
+		builder.addCommand(cmd)
+
+		expect(builder.getPackets()).toHaveLength(1)
+		expect(builder.getPackets()).toHaveLength(1) // Ensure that calling it twice doesnt affect the output
+		expect(builder.getPackets()[0]).toHaveLength(cmd.lengthWithHeader)
+	})
+
+	it('Once finished cant add more commands', () => {
+		const builder = new PacketBuilder(500, ProtocolVersion.V8_1_1)
+
+		const cmd = new FakeCommand(10)
+		builder.addCommand(cmd)
+
+		expect(builder.getPackets()).toHaveLength(1)
+
+		expect(() => builder.addCommand(cmd)).toThrow('finished')
+	})
+
+	it('Repeated command', () => {
+		const builder = new PacketBuilder(500, ProtocolVersion.V8_1_1)
+
+		const cmd = new FakeCommand(10)
+		for (let i = 0; i < 5; i++) {
+			builder.addCommand(cmd)
+		}
+
+		expect(builder.getPackets()).toHaveLength(1)
+		expect(builder.getPackets()[0]).toHaveLength(cmd.lengthWithHeader * 5)
+	})
+
+	it('Repeated command spanning multiple packets', () => {
+		const builder = new PacketBuilder(500, ProtocolVersion.V8_1_1)
+
+		const cmd = new FakeCommand(10)
+		for (let i = 0; i < 60; i++) {
+			builder.addCommand(cmd)
+		}
+
+		expect(cmd.lengthWithHeader).toBe(18)
+		expect(builder.getPackets()).toHaveLength(3)
+
+		expect(builder.getPackets()[0]).toHaveLength(cmd.lengthWithHeader * 27)
+		expect(builder.getPackets()[1]).toHaveLength(cmd.lengthWithHeader * 27)
+		expect(builder.getPackets()[2]).toHaveLength(cmd.lengthWithHeader * 6)
+	})
+
+	it('Command too large to fit a packets', () => {
+		const builder = new PacketBuilder(500, ProtocolVersion.V8_1_1)
+
+		const cmd = new FakeCommand(501)
+		expect(() => builder.addCommand(cmd)).toThrow('too large')
+	})
+
+	it('Command same size as packet', () => {
+		const builder = new PacketBuilder(500, ProtocolVersion.V8_1_1)
+
+		const cmd = new FakeCommand(500 - 8)
+		expect(cmd.lengthWithHeader).toBe(500)
+
+		builder.addCommand(cmd)
+		expect(builder.getPackets()).toHaveLength(1)
+		expect(builder.getPackets()[0]).toHaveLength(cmd.lengthWithHeader)
+	})
+
+	it('Commands of mixed sizes', () => {
+		const builder = new PacketBuilder(500, ProtocolVersion.V8_1_1)
+
+		const largeCmd = new FakeCommand(400)
+		const mediumCmd = new FakeCommand(80)
+		const smallCmd = new FakeCommand(10)
+
+		// packet 0:
+		builder.addCommand(mediumCmd)
+		builder.addCommand(smallCmd)
+
+		// packet 1:
+		builder.addCommand(largeCmd)
+		builder.addCommand(mediumCmd)
+
+		// packet 2:
+		builder.addCommand(smallCmd)
+		builder.addCommand(smallCmd)
+		builder.addCommand(largeCmd)
+
+		expect(builder.getPackets()).toHaveLength(3)
+		expect(builder.getPackets()[0]).toHaveLength(mediumCmd.lengthWithHeader + smallCmd.lengthWithHeader)
+		expect(builder.getPackets()[1]).toHaveLength(largeCmd.lengthWithHeader + mediumCmd.lengthWithHeader)
+		expect(builder.getPackets()[2]).toHaveLength(
+			smallCmd.lengthWithHeader + smallCmd.lengthWithHeader + largeCmd.lengthWithHeader
+		)
+	})
+})

--- a/src/lib/__tests__/packetBuilder.spec.ts
+++ b/src/lib/__tests__/packetBuilder.spec.ts
@@ -76,7 +76,14 @@ describe('PacketBuilder', () => {
 		const builder = new PacketBuilder(500, ProtocolVersion.V8_1_1)
 
 		const cmd = new FakeCommand(501)
-		expect(() => builder.addCommand(cmd)).toThrow('too large')
+		expect(cmd.lengthWithHeader).toBe(501 + 8)
+		const smallCmd = new FakeCommand(10)
+
+		builder.addCommand(cmd)
+		builder.addCommand(smallCmd)
+		expect(builder.getPackets()).toHaveLength(2)
+		expect(builder.getPackets()[0]).toHaveLength(cmd.lengthWithHeader)
+		expect(builder.getPackets()[1]).toHaveLength(smallCmd.lengthWithHeader)
 	})
 
 	it('Command same size as packet', () => {

--- a/src/lib/__tests__/socket-child.spec.ts
+++ b/src/lib/__tests__/socket-child.spec.ts
@@ -32,7 +32,7 @@ function fakeConnect(child: AtemSocketChild): void {
 
 function createSocketChild(
 	onCommandsReceived?: (payload: Buffer, packetId: number) => Promise<void>,
-	onCommandsAcknowledged?: (ids: Array<{ packetId: number; trackingId: number }>) => Promise<void>,
+	onPacketsAcknowledged?: (ids: Array<{ packetId: number; trackingId: number }>) => Promise<void>,
 	onDisconnect?: () => Promise<void>
 ): AtemSocketChild {
 	return new AtemSocketChild(
@@ -45,7 +45,7 @@ function createSocketChild(
 		// async msg => { console.log(msg) },
 		async (): Promise<void> => Promise.resolve(),
 		onCommandsReceived || (async (): Promise<void> => Promise.resolve()),
-		onCommandsAcknowledged || (async (): Promise<void> => Promise.resolve())
+		onPacketsAcknowledged || (async (): Promise<void> => Promise.resolve())
 	)
 }
 

--- a/src/lib/__tests__/socket-child.spec.ts
+++ b/src/lib/__tests__/socket-child.spec.ts
@@ -396,14 +396,20 @@ describe('SocketChild', () => {
 			}
 
 			// Send something
-			const buf1 = [0, 1, 2]
+			const buf1 = Buffer.from([0, 1, 2])
 			const cmdName = 'test'
 			const buf1Expected = Buffer.alloc(11)
 			buf1Expected.writeUInt16BE(buf1Expected.length, 0)
 			buf1Expected.write(cmdName, 4, 4)
 			Buffer.from(buf1).copy(buf1Expected, 8)
 
-			child.sendCommands([{ payload: buf1, rawName: cmdName, trackingId: 1 }])
+			child.sendPackets([
+				{
+					payloadLength: buf1Expected.length,
+					payloadHex: buf1Expected.toString('hex'),
+					trackingId: 1,
+				},
+			])
 			expect(received).toEqual([
 				{
 					id: 123,
@@ -414,7 +420,13 @@ describe('SocketChild', () => {
 			expect(getInflightIds(child)).toEqual([123])
 
 			// Send another
-			child.sendCommands([{ payload: buf1, rawName: cmdName, trackingId: 1 }])
+			child.sendPackets([
+				{
+					payloadLength: buf1Expected.length,
+					payloadHex: buf1Expected.toString('hex'),
+					trackingId: 1,
+				},
+			])
 			expect(received).toEqual([
 				{
 					id: 124,
@@ -472,16 +484,16 @@ describe('SocketChild', () => {
 			acked = []
 
 			// Send some stuff
-			const buf1 = [0, 1, 2]
-			child.sendCommands([
-				{ payload: buf1, rawName: '', trackingId: 5 },
-				{ payload: buf1, rawName: '', trackingId: 6 },
-				{ payload: buf1, rawName: '', trackingId: 7 },
+			const buf1 = Buffer.from([0, 1, 2])
+			child.sendPackets([
+				{ payloadLength: buf1.length, payloadHex: buf1.toString('hex'), trackingId: 5 },
+				{ payloadLength: buf1.length, payloadHex: buf1.toString('hex'), trackingId: 6 },
+				{ payloadLength: buf1.length, payloadHex: buf1.toString('hex'), trackingId: 7 },
 			])
-			child.sendCommands([{ payload: buf1, rawName: '', trackingId: 8 }])
-			child.sendCommands([
-				{ payload: buf1, rawName: '', trackingId: 9 },
-				{ payload: buf1, rawName: '', trackingId: 10 },
+			child.sendPackets([{ payloadLength: buf1.length, payloadHex: buf1.toString('hex'), trackingId: 8 }])
+			child.sendPackets([
+				{ payloadLength: buf1.length, payloadHex: buf1.toString('hex'), trackingId: 9 },
+				{ payloadLength: buf1.length, payloadHex: buf1.toString('hex'), trackingId: 10 },
 			])
 			expect(received).toEqual([123, 124, 125, 126, 127, 128])
 			received = []
@@ -531,18 +543,18 @@ describe('SocketChild', () => {
 			acked = []
 
 			// Send some stuff
-			const buf1 = [0, 1, 2]
-			child.sendCommands([
-				{ payload: buf1, rawName: '', trackingId: 5 }, // 32764
-				{ payload: buf1, rawName: '', trackingId: 6 }, // 32765
-				{ payload: buf1, rawName: '', trackingId: 7 }, // 32766
+			const buf1 = Buffer.from([0, 1, 2])
+			child.sendPackets([
+				{ payloadLength: buf1.length, payloadHex: buf1.toString('hex'), trackingId: 5 }, // 32764
+				{ payloadLength: buf1.length, payloadHex: buf1.toString('hex'), trackingId: 6 }, // 32765
+				{ payloadLength: buf1.length, payloadHex: buf1.toString('hex'), trackingId: 7 }, // 32766
 			])
-			child.sendCommands([
-				{ payload: buf1, rawName: '', trackingId: 8 }, // 32767
+			child.sendPackets([
+				{ payloadLength: buf1.length, payloadHex: buf1.toString('hex'), trackingId: 8 }, // 32767
 			])
-			child.sendCommands([
-				{ payload: buf1, rawName: '', trackingId: 9 }, // 0
-				{ payload: buf1, rawName: '', trackingId: 10 }, // 1
+			child.sendPackets([
+				{ payloadLength: buf1.length, payloadHex: buf1.toString('hex'), trackingId: 9 }, // 0
+				{ payloadLength: buf1.length, payloadHex: buf1.toString('hex'), trackingId: 10 }, // 1
 			])
 			expect(received).toEqual([32764, 32765, 32766, 32767, 0, 1])
 			received = []
@@ -595,14 +607,14 @@ describe('SocketChild', () => {
 			acked = []
 
 			// Send some stuff
-			const buf1 = [0, 1, 2]
-			child.sendCommands([
-				{ payload: buf1, rawName: '', trackingId: 5 }, // 32764
-				{ payload: buf1, rawName: '', trackingId: 6 }, // 32765
-				{ payload: buf1, rawName: '', trackingId: 7 }, // 32766
-				{ payload: buf1, rawName: '', trackingId: 8 }, // 32767
-				{ payload: buf1, rawName: '', trackingId: 9 }, // 0
-				{ payload: buf1, rawName: '', trackingId: 10 }, // 1
+			const buf1 = Buffer.from([0, 1, 2])
+			child.sendPackets([
+				{ payloadLength: buf1.length, payloadHex: buf1.toString('hex'), trackingId: 5 }, // 32764
+				{ payloadLength: buf1.length, payloadHex: buf1.toString('hex'), trackingId: 6 }, // 32765
+				{ payloadLength: buf1.length, payloadHex: buf1.toString('hex'), trackingId: 7 }, // 32766
+				{ payloadLength: buf1.length, payloadHex: buf1.toString('hex'), trackingId: 8 }, // 32767
+				{ payloadLength: buf1.length, payloadHex: buf1.toString('hex'), trackingId: 9 }, // 0
+				{ payloadLength: buf1.length, payloadHex: buf1.toString('hex'), trackingId: 10 }, // 1
 			])
 			expect(received).toEqual([32764, 32765, 32766, 32767, 0, 1])
 			received = []
@@ -631,8 +643,8 @@ describe('SocketChild', () => {
 			received = []
 
 			// Add another to the queue
-			child.sendCommands([
-				{ payload: buf1, rawName: '', trackingId: 11 }, // 2
+			child.sendPackets([
+				{ payloadLength: buf1.length, payloadHex: buf1.toString('hex'), trackingId: 11 }, // 2
 			])
 			expect(received).toEqual([2])
 			received = []
@@ -692,14 +704,14 @@ describe('SocketChild', () => {
 			acked = []
 
 			// Send some stuff
-			const buf1 = [0, 1, 2]
-			child.sendCommands([
-				{ payload: buf1, rawName: '', trackingId: 5 }, // 32764
-				{ payload: buf1, rawName: '', trackingId: 6 }, // 32765
-				{ payload: buf1, rawName: '', trackingId: 7 }, // 32766
-				{ payload: buf1, rawName: '', trackingId: 8 }, // 32767
-				{ payload: buf1, rawName: '', trackingId: 9 }, // 0
-				{ payload: buf1, rawName: '', trackingId: 10 }, // 1
+			const buf1 = Buffer.from([0, 1, 2])
+			child.sendPackets([
+				{ payloadLength: buf1.length, payloadHex: buf1.toString('hex'), trackingId: 5 }, // 32764
+				{ payloadLength: buf1.length, payloadHex: buf1.toString('hex'), trackingId: 6 }, // 32765
+				{ payloadLength: buf1.length, payloadHex: buf1.toString('hex'), trackingId: 7 }, // 32766
+				{ payloadLength: buf1.length, payloadHex: buf1.toString('hex'), trackingId: 8 }, // 32767
+				{ payloadLength: buf1.length, payloadHex: buf1.toString('hex'), trackingId: 9 }, // 0
+				{ payloadLength: buf1.length, payloadHex: buf1.toString('hex'), trackingId: 10 }, // 1
 			])
 			expect(received).toEqual([32764, 32765, 32766, 32767, 0, 1])
 			received = []
@@ -753,10 +765,10 @@ describe('SocketChild', () => {
 			connected = true
 
 			// Send some stuff
-			const buf1 = [0, 1, 2]
-			child.sendCommands([
-				{ payload: buf1, rawName: '', trackingId: 5 }, // 32767
-				{ payload: buf1, rawName: '', trackingId: 6 }, // 0
+			const buf1 = Buffer.from([0, 1, 2])
+			child.sendPackets([
+				{ payloadLength: buf1.length, payloadHex: buf1.toString('hex'), trackingId: 5 }, // 32767
+				{ payloadLength: buf1.length, payloadHex: buf1.toString('hex'), trackingId: 6 }, // 0
 			])
 			expect(getInflightIds(child)).toEqual([32767, 0])
 			expect(acked).toEqual([])
@@ -793,10 +805,10 @@ describe('SocketChild', () => {
 			connected = true
 
 			// Send some stuff
-			const buf1 = [0, 1, 2]
-			child.sendCommands([
-				{ payload: buf1, rawName: '', trackingId: 5 }, // 32767
-				{ payload: buf1, rawName: '', trackingId: 6 }, // 0
+			const buf1 = Buffer.from([0, 1, 2])
+			child.sendPackets([
+				{ payloadLength: buf1.length, payloadHex: buf1.toString('hex'), trackingId: 5 }, // 32767
+				{ payloadLength: buf1.length, payloadHex: buf1.toString('hex'), trackingId: 6 }, // 0
 			])
 			expect(getInflightIds(child)).toEqual([32767, 0])
 			expect(acked).toEqual([])
@@ -835,10 +847,10 @@ describe('SocketChild', () => {
 			acked = []
 
 			// Send some stuff
-			const buf1 = [0, 1, 2]
-			child.sendCommands([
-				{ payload: buf1, rawName: '', trackingId: 5 }, // 32767
-				{ payload: buf1, rawName: '', trackingId: 6 }, // 0
+			const buf1 = Buffer.from([0, 1, 2])
+			child.sendPackets([
+				{ payloadLength: buf1.length, payloadHex: buf1.toString('hex'), trackingId: 5 }, // 32767
+				{ payloadLength: buf1.length, payloadHex: buf1.toString('hex'), trackingId: 6 }, // 0
 			])
 			expect(getInflightIds(child)).toEqual([32767, 0])
 			expect(acked).toEqual([])
@@ -868,8 +880,8 @@ describe('SocketChild', () => {
 			// Not quite
 			await clock.tickAsync(1990)
 			expect(connected).toBeTrue()
-			child.sendCommands([
-				{ payload: buf1, rawName: '', trackingId: 7 }, // 1
+			child.sendPackets([
+				{ payloadLength: buf1.length, payloadHex: buf1.toString('hex'), trackingId: 7 }, // 1
 			])
 			expect(getInflightIds(child)).toEqual([1])
 			expect(acked).toEqual([])

--- a/src/lib/atemSocket.ts
+++ b/src/lib/atemSocket.ts
@@ -13,7 +13,7 @@ export interface AtemSocketOptions {
 	debugBuffers: boolean
 	disableMultithreaded: boolean
 	childProcessTimeout: number
-	packetMtu: number
+	maxPacketSize: number
 }
 
 export type AtemSocketEvents = {
@@ -29,7 +29,7 @@ export class AtemSocket extends EventEmitter<AtemSocketEvents> {
 	private readonly _debugBuffers: boolean
 	private readonly _disableMultithreaded: boolean
 	private readonly _childProcessTimeout: number
-	private readonly _packetMtu: number
+	private readonly _maxPacketSize: number
 	private readonly _commandParser: CommandParser = new CommandParser()
 
 	private _nextPacketTrackingId = 0
@@ -47,7 +47,7 @@ export class AtemSocket extends EventEmitter<AtemSocketEvents> {
 		this._debugBuffers = options.debugBuffers
 		this._disableMultithreaded = options.disableMultithreaded
 		this._childProcessTimeout = options.childProcessTimeout
-		this._packetMtu = options.packetMtu
+		this._maxPacketSize = options.maxPacketSize
 	}
 
 	public async connect(address?: string, port?: number): Promise<void> {
@@ -107,7 +107,7 @@ export class AtemSocket extends EventEmitter<AtemSocketEvents> {
 	public async sendCommands(commands: Array<ISerializableCommand>): Promise<number[]> {
 		if (!this._socketProcess) throw new Error('Socket process is not open')
 
-		const maxPacketSize = this._packetMtu - 28 - 12 // MTU minus UDP header and ATEM header
+		const maxPacketSize = this._maxPacketSize - 12 // MTU minus ATEM header
 		const packetBuilder = new PacketBuilder(maxPacketSize, this._commandParser.version)
 
 		for (const cmd of commands) {

--- a/src/lib/atemSocket.ts
+++ b/src/lib/atemSocket.ts
@@ -20,8 +20,8 @@ export type AtemSocketEvents = {
 	info: [string]
 	debug: [string]
 	error: [string]
-	commandsReceived: [IDeserializedCommand[]]
-	commandsAck: [number[]]
+	receivedCommands: [IDeserializedCommand[]]
+	ackPackets: [number[]]
 }
 
 export class AtemSocket extends EventEmitter<AtemSocketEvents> {
@@ -194,10 +194,10 @@ export class AtemSocket extends EventEmitter<AtemSocketEvents> {
 				}, // onCommandsReceived
 				async (ids: Array<{ packetId: number; trackingId: number }>): Promise<void> => {
 					this.emit(
-						'commandsAck',
+						'ackPackets',
 						ids.map((id) => id.trackingId)
 					)
-				}, // onCommandsAcknowledged
+				}, // onPacketsAcknowledged
 			],
 			{
 				instanceName: 'atem-connection',
@@ -260,7 +260,7 @@ export class AtemSocket extends EventEmitter<AtemSocketEvents> {
 		}
 
 		if (parsedCommands.length > 0) {
-			this.emit('commandsReceived', parsedCommands)
+			this.emit('receivedCommands', parsedCommands)
 		}
 		return parsedCommands
 	}

--- a/src/lib/atemSocket.ts
+++ b/src/lib/atemSocket.ts
@@ -31,7 +31,7 @@ export class AtemSocket extends EventEmitter<AtemSocketEvents> {
 	private readonly _packetMtu: number
 	private readonly _commandParser: CommandParser = new CommandParser()
 
-	private _nextCommandTrackingId = 0
+	private _nextPacketTrackingId = 0
 	private _isDisconnecting = false
 	private _address: string
 	private _port: number = DEFAULT_PORT
@@ -96,11 +96,11 @@ export class AtemSocket extends EventEmitter<AtemSocketEvents> {
 		}
 	}
 
-	get nextCommandTrackingId(): number {
-		if (this._nextCommandTrackingId >= Number.MAX_SAFE_INTEGER) {
-			this._nextCommandTrackingId = 0
+	get nextPacketTrackingId(): number {
+		if (this._nextPacketTrackingId >= Number.MAX_SAFE_INTEGER) {
+			this._nextPacketTrackingId = 0
 		}
-		return ++this._nextCommandTrackingId
+		return ++this._nextPacketTrackingId
 	}
 
 	public async sendCommands(commands: Array<ISerializableCommand>): Promise<number[]> {
@@ -118,7 +118,7 @@ export class AtemSocket extends EventEmitter<AtemSocketEvents> {
 		const startNewBuffer = (skipCreate?: boolean) => {
 			if (currentPacketFilled === 0) return
 
-			const trackingId = this.nextCommandTrackingId
+			const trackingId = this.nextPacketTrackingId
 			trackingIds.push(trackingId)
 
 			packets.push({

--- a/src/lib/atemSocketChild.ts
+++ b/src/lib/atemSocketChild.ts
@@ -72,7 +72,7 @@ export class AtemSocketChild {
 	private readonly onDisconnect: () => Promise<void>
 	private readonly onLog: (message: string) => Promise<void>
 	private readonly onCommandsReceived: (payload: Buffer, packetId: number) => Promise<void>
-	private readonly onCommandsAcknowledged: (ids: Array<{ packetId: number; trackingId: number }>) => Promise<void>
+	private readonly onPacketsAcknowledged: (ids: Array<{ packetId: number; trackingId: number }>) => Promise<void>
 
 	constructor(
 		options: { address: string; port: number; debugBuffers: boolean },
@@ -88,7 +88,7 @@ export class AtemSocketChild {
 		this.onDisconnect = onDisconnect
 		this.onLog = onLog
 		this.onCommandsReceived = onCommandReceived
-		this.onCommandsAcknowledged = onCommandAcknowledged
+		this.onPacketsAcknowledged = onCommandAcknowledged
 
 		this._socket = this._createSocket()
 	}
@@ -308,7 +308,7 @@ export class AtemSocketChild {
 						return true
 					}
 				})
-				ps.push(this.onCommandsAcknowledged(ackedCommands))
+				ps.push(this.onPacketsAcknowledged(ackedCommands))
 				// this.log(`${Date.now()} Got ack ${ackPacketId} Remaining=${this._inFlight.length}`)
 			}
 		}
@@ -396,7 +396,7 @@ export class AtemSocketChild {
 					// Retransmit the packet and anything after it
 					return this._retransmitFrom(sentPacket.packetId)
 				} else {
-					// A command has timed out, so we need to reset to avoid getting stuck
+					// A packet has timed out, so we need to reset to avoid getting stuck
 					this.log(`Packet timed out: ${sentPacket.packetId}`)
 					return this.restartConnection()
 				}

--- a/src/lib/atemSocketChild.ts
+++ b/src/lib/atemSocketChild.ts
@@ -42,6 +42,12 @@ interface InFlightPacket {
 	resent: number
 }
 
+export interface OutboundPacketInfo {
+	payloadLength: number
+	payloadHex: string
+	trackingId: number
+}
+
 export class AtemSocketChild {
 	private readonly _debugBuffers: boolean
 
@@ -167,7 +173,7 @@ export class AtemSocketChild {
 		void this.onLog(message)
 	}
 
-	public sendPackets(packets: Array<{ payloadLength: number; payloadHex: string; trackingId: number }>): void {
+	public sendPackets(packets: OutboundPacketInfo[]): void {
 		for (const packet of packets) {
 			this.sendPacket(packet.payloadLength, packet.payloadHex, packet.trackingId)
 		}

--- a/src/lib/packetBuilder.ts
+++ b/src/lib/packetBuilder.ts
@@ -1,0 +1,66 @@
+import type { ProtocolVersion } from '../enums'
+import type { ISerializableCommand } from '../commands'
+
+export class PacketBuilder {
+	readonly #maxPacketSize: number
+	readonly #protocolVersion: ProtocolVersion
+
+	readonly #completedBuffers: Buffer[] = []
+
+	#currentPacketBuffer: Buffer
+	#currentPacketFilled: number
+
+	constructor(maxPacketSize: number, protocolVersion: ProtocolVersion) {
+		this.#maxPacketSize = maxPacketSize
+		this.#protocolVersion = protocolVersion
+
+		this.#currentPacketBuffer = Buffer.alloc(maxPacketSize)
+		this.#currentPacketFilled = 0
+	}
+
+	public addCommand(cmd: ISerializableCommand): void {
+		if (typeof cmd.serialize !== 'function') {
+			throw new Error(`Command ${cmd.constructor.name} is not serializable`)
+		}
+
+		const payload = cmd.serialize(this.#protocolVersion)
+
+		const rawName: string = (cmd.constructor as any).rawName
+
+		const totalLength = payload.length + 8
+		if (totalLength >= this.#maxPacketSize) {
+			throw new Error(`Comamnd ${cmd.constructor.name} is too large for a single packet`)
+		}
+
+		// Ensure the packet will fit into the current buffer
+		if (totalLength + this.#currentPacketFilled > this.#maxPacketSize) {
+			this.#finishBuffer()
+		}
+
+		// Command name
+		this.#currentPacketBuffer.writeUInt16BE(payload.length + 8, this.#currentPacketFilled + 0)
+		this.#currentPacketBuffer.write(rawName, this.#currentPacketFilled + 4, 4)
+
+		// Body
+		payload.copy(this.#currentPacketBuffer, this.#currentPacketFilled + 8)
+
+		this.#currentPacketFilled += totalLength
+	}
+
+	public getPackets(): Buffer[] {
+		this.#finishBuffer(true)
+
+		return this.#completedBuffers
+	}
+
+	#finishBuffer(skipCreateNext?: boolean) {
+		if (this.#currentPacketFilled === 0) return
+
+		this.#completedBuffers.push(this.#currentPacketBuffer.subarray(0, this.#currentPacketFilled))
+
+		if (!skipCreateNext) {
+			this.#currentPacketBuffer = Buffer.alloc(this.#maxPacketSize)
+			this.#currentPacketFilled = 0
+		}
+	}
+}

--- a/src/lib/packetBuilder.ts
+++ b/src/lib/packetBuilder.ts
@@ -48,19 +48,19 @@ export class PacketBuilder {
 	}
 
 	public getPackets(): Buffer[] {
-		this.#finishBuffer(true)
+		this.#finishBuffer(false)
 
 		this.#finished = true
 
 		return this.#completedBuffers
 	}
 
-	#finishBuffer(skipCreateNext?: boolean) {
+	#finishBuffer(allocNewBuffer = true) {
 		if (this.#currentPacketFilled === 0 || this.#finished) return
 
 		this.#completedBuffers.push(this.#currentPacketBuffer.subarray(0, this.#currentPacketFilled))
 
-		if (!skipCreateNext) {
+		if (allocNewBuffer) {
 			this.#currentPacketBuffer = Buffer.alloc(this.#maxPacketSize)
 			this.#currentPacketFilled = 0
 		}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature

* **What is the current behavior?** (You can also link to an open issue here)

When sending commands to the atem, it is only possible to send one per packet.

* **What is the new behavior (if this is a feature change)?**

The `sendCommands` method is now exposed, allowing for sending multiple commands in one packet. 
Each call to the method will result in packets being sent, no buffering/debouncing is performed between calls. Commands are packed into packets in order, up to a defined byte limit per packet.

The maximum packet size is defined based on the `packetMtu` property supplied to the constructor. Care should be taken when setting this, as any upload transfers do not fully respect this value and will result in packets failing to send.

* **Other information**:

This partially covers https://github.com/nrkno/sofie-atem-connection/issues/140, but only solves the case of constructing the commands manually (or with `atem-state`), not usage through the methods provided on the `Atem` class.  
A friendlier batching api can be built on top of this work by someone later.

I have tested this against a Constellation 2ME HD by sending a pair of `MixEffectKeyDVECommand` commands multiple time at once, enough so that it spans multiple packets. The packets were acked, indicating that they were transmitted and received successfully.