### PR TITLE
feat: support external colour conversions in uploadStill and uploadClip api

### DIFF
--- a/src/atem.ts
+++ b/src/atem.ts
@@ -749,6 +749,19 @@ export class Atem extends BasicAtem {
 		return this.sendCommand(command)
 	}
 
+	/**
+	 * Upload a still image to the ATEM media pool
+	 *
+	 * Note: This performs colour conversions in JS, which is not very CPU efficient. If performance is important,
+	 * consider using [@atem-connection/image-tools](https://www.npmjs.com/package/@atem-connection/image-tools) to
+	 * pre-convert the images with more optimal algorithms
+	 * @param index Still index to upload to
+	 * @param data a RGBA pixel buffer, or an already YUVA encoded image
+	 * @param name Name to give the uploaded image
+	 * @param description Description for the uploaded image
+	 * @param options Upload options
+	 * @returns Promise which resolves once the image is uploaded
+	 */
 	public async uploadStill(
 		index: number,
 		data: Buffer | UploadBufferInfo,
@@ -765,6 +778,18 @@ export class Atem extends BasicAtem {
 		return this.dataTransferManager.uploadStill(index, encodedData, name, description)
 	}
 
+	/**
+	 * Upload a clip to the ATEM media pool
+	 *
+	 * Note: This performs colour conversions in JS, which is not very CPU efficient. If performance is important,
+	 * consider using [@atem-connection/image-tools](https://www.npmjs.com/package/@atem-connection/image-tools) to
+	 * pre-convert the images with more optimal algorithms
+	 * @param index Clip index to upload to
+	 * @param frames Array or generator of frames. Each frame can be a RGBA pixel buffer, or an already YUVA encoded image
+	 * @param name Name to give the uploaded clip
+	 * @param options Upload options
+	 * @returns Promise which resolves once the clip is uploaded
+	 */
 	public async uploadClip(
 		index: number,
 		frames: Iterable<Buffer> | AsyncIterable<Buffer> | Iterable<UploadBufferInfo> | AsyncIterable<UploadBufferInfo>,
@@ -783,6 +808,13 @@ export class Atem extends BasicAtem {
 		return this.dataTransferManager.uploadClip(index, provideFrame(), name)
 	}
 
+	/**
+	 * Upload clip audio to the ATEM media pool
+	 * @param index Clip index to upload to
+	 * @param data stereo 48khz 24bit WAV audio data
+	 * @param name Name to give the uploaded audio
+	 * @returns Promise which resolves once the clip audio is uploaded
+	 */
 	public async uploadAudio(index: number, data: Buffer, name: string): Promise<void> {
 		return this.dataTransferManager.uploadAudio(index, Util.convertWAVToRaw(data, this.state?.info?.model), name)
 	}

--- a/src/dataTransfer/__tests__/index.spec.ts
+++ b/src/dataTransfer/__tests__/index.spec.ts
@@ -2,7 +2,8 @@ import * as DataTransferCommands from '../../commands/DataTransfer'
 import { readFileSync } from 'fs'
 import * as path from 'path'
 import { DataTransferManager } from '..'
-import { Commands } from '../..'
+import { Commands, UploadBufferInfo } from '../..'
+import { generateHashForBuffer } from '../dataTransferUploadBuffer'
 
 function specToCommandClass(spec: any): Commands.IDeserializedCommand | undefined {
 	for (const commandName in DataTransferCommands) {
@@ -59,9 +60,15 @@ test('Still upload', async () => {
 	const spec: any[] = JSON.parse(readFileSync(path.join(__dirname, './upload-still-sequence.json')).toString())
 
 	const newBuffer = Buffer.alloc(1920 * 1080 * 4, 0)
+	const wrappedBuffer: UploadBufferInfo = {
+		encodedData: newBuffer,
+		rawDataLength: newBuffer.length,
+		isRleEncoded: false,
+		hash: generateHashForBuffer(newBuffer),
+	}
 
 	const manager = runDataTransferTest(spec)
-	await manager.uploadStill(2, newBuffer, 'some still', '', { disableRLE: true })
+	await manager.uploadStill(2, wrappedBuffer, 'some still', '')
 
 	await new Promise((resolve) => setTimeout(resolve, 200))
 
@@ -87,9 +94,15 @@ test('clip upload', async () => {
 	const spec: any[] = JSON.parse(readFileSync(path.join(__dirname, './upload-clip-sequence.json')).toString())
 
 	const newBuffer = Buffer.alloc(1920 * 1080 * 4, 0)
+	const wrappedBuffer: UploadBufferInfo = {
+		encodedData: newBuffer,
+		rawDataLength: newBuffer.length,
+		isRleEncoded: false,
+		hash: generateHashForBuffer(newBuffer),
+	}
 
 	const manager = runDataTransferTest(spec)
-	await manager.uploadClip(1, [newBuffer, newBuffer, newBuffer], 'clip file', { disableRLE: true })
+	await manager.uploadClip(1, [wrappedBuffer, wrappedBuffer, wrappedBuffer], 'clip file')
 
 	await new Promise((resolve) => setTimeout(resolve, 200))
 

--- a/src/dataTransfer/dataTransferUploadAudio.ts
+++ b/src/dataTransfer/dataTransferUploadAudio.ts
@@ -11,6 +11,7 @@ export default class DataTransferUploadAudio extends DataTransferUploadBuffer {
 		super({
 			encodedData: data,
 			rawDataLength: data.length,
+			isRleEncoded: false,
 			hash: null,
 		})
 

--- a/src/dataTransfer/dataTransferUploadBuffer.ts
+++ b/src/dataTransfer/dataTransferUploadBuffer.ts
@@ -15,9 +15,23 @@ import * as Util from '../lib/atemUtil'
 const debug = debug0('atem-connection:data-transfer:upload-buffer')
 
 export interface UploadBufferInfo {
+	/**
+	 * Encoded data in ATEM native format (eg YUVA for pixels, 24bit audio)
+	 */
 	encodedData: Buffer
+	/**
+	 * Length of the encoded data, before any RLE encoding
+	 */
 	rawDataLength: number
+	/**
+	 * Whether RLE encoding has been performed on this buffer (when supported)
+	 */
 	isRleEncoded: boolean
+	/**
+	 * Hash for the encoded data, intended as a unique identifier/checksum
+	 * When `null`, one will be generated from the `encodedData`
+	 * This is returned by the ATEM when describing what is in each slot
+	 */
 	hash: string | null
 }
 

--- a/src/dataTransfer/dataTransferUploadMacro.ts
+++ b/src/dataTransfer/dataTransferUploadMacro.ts
@@ -8,6 +8,7 @@ export class DataTransferUploadMacro extends DataTransferUploadBuffer {
 		super({
 			encodedData: data,
 			rawDataLength: data.length,
+			isRleEncoded: false,
 			hash: null,
 		})
 	}

--- a/src/dataTransfer/dataTransferUploadMultiViewerLabel.ts
+++ b/src/dataTransfer/dataTransferUploadMultiViewerLabel.ts
@@ -10,6 +10,7 @@ export default class DataTransferUploadMultiViewerLabel extends DataTransferUplo
 		super({
 			encodedData: data,
 			rawDataLength: data.length,
+			isRleEncoded: false,
 			hash: null,
 		})
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,4 +15,5 @@ import * as InputState from './state/input'
 import * as MacroState from './state/macro'
 import * as SettingsState from './state/settings'
 export { VideoState, AudioState, MediaState, InfoState, InputState, MacroState, SettingsState }
-export { UploadStillEncodingOptions } from './dataTransfer'
+export type { UploadStillEncodingOptions } from './dataTransfer'
+export type { UploadBufferInfo } from './dataTransfer/dataTransferUploadBuffer'


### PR DESCRIPTION
## About the Contributor
This pull request is posted on behalf of the myself.


## Type of Contribution

This is a Feature

## Current Behavior
When uploading a clip or still to the ATEM, this library is assuming the input to be rgba encoded, and is converting it to the required YUVA422 in js. This is not very efficient, and can be rather limiting.


## New Behavior
This exposes more detailed types in the api, to allow for doing this colour conversion externally. 



## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->

This replaces https://github.com/nrkno/sofie-atem-connection/pull/152, following the feedback received there, and feedback 2023-10-06 dev meeting.

See that PR for details on why this may want to be done externally.

## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
