### PR TITLE
feat: replace threadedclass with comlink

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "nanotimer": "^0.3.15",
     "p-lazy": "^3.1.0",
     "p-queue": "^6.6.2",
-    "threadedclass": "^1.2.1",
     "tslib": "^2.6.2",
     "wavefile": "^8.4.6"
   },

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   ],
   "dependencies": {
     "@julusian/freetype2": "^1.1.2",
-    "comlink": "^4.4.1",
+    "comlink": "npm:@superflytv/comlink@^4.4.2",
     "debug": "^4.3.4",
     "eventemitter3": "^4.0.7",
     "exit-hook": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
   ],
   "dependencies": {
     "@julusian/freetype2": "^1.1.2",
+    "comlink": "^4.4.1",
     "debug": "^4.3.4",
     "eventemitter3": "^4.0.7",
     "exit-hook": "^2.2.1",

--- a/src/__tests__/atem.spec.ts
+++ b/src/__tests__/atem.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/unbound-method */
-import { Atem, DEFAULT_MAX_PACKET_SIZE, DEFAULT_PORT } from '../atem'
+import { Atem, DEFAULT_MAX_PACKET_SIZE } from '../atem'
 import { CutCommand } from '../commands'
 import { promisify } from 'util'
 import { EventEmitter } from 'events'
@@ -29,12 +29,9 @@ describe('Atem', () => {
 
 			expect(AtemSocket).toHaveBeenCalledTimes(1)
 			expect(AtemSocket).toHaveBeenCalledWith({
-				address: '',
-				childProcessTimeout: 600,
 				debugBuffers: false,
 				disableMultithreaded: true,
 				log: (conn as any)._log,
-				port: DEFAULT_PORT,
 				maxPacketSize: DEFAULT_MAX_PACKET_SIZE,
 			})
 		} finally {
@@ -50,12 +47,9 @@ describe('Atem', () => {
 
 			expect(AtemSocket).toHaveBeenCalledTimes(1)
 			expect(AtemSocket).toHaveBeenCalledWith({
-				address: 'test1',
-				childProcessTimeout: 600,
 				debugBuffers: true,
 				disableMultithreaded: false,
 				log: (conn as any)._log,
-				port: 23,
 				maxPacketSize: 500,
 			})
 		} finally {

--- a/src/__tests__/connection.spec.ts
+++ b/src/__tests__/connection.spec.ts
@@ -58,7 +58,7 @@ function createConnection(): BasicAtem {
 }
 
 function getChild(conn: BasicAtem): AtemSocketChildMock {
-	return (conn as any).socket._socketProcess
+	return (conn as any).socket._socketProcess.wrappedChild
 }
 
 function runTest(name: string, filename: string): void {
@@ -113,8 +113,6 @@ function runTest(name: string, filename: string): void {
 			expect(state).toBeTruthy()
 
 			const state0 = state as AtemState
-
-			commands.length = 0
 
 			for (const cmd of commands) {
 				test(`${cmd.constructor.name}`, async () => {

--- a/src/__tests__/connection.spec.ts
+++ b/src/__tests__/connection.spec.ts
@@ -2,7 +2,6 @@
 import { readFileSync } from 'fs'
 import { resolve } from 'path'
 import { AtemSocketChild } from '../lib/atemSocketChild'
-import { ThreadedClass } from 'threadedclass'
 import { BasicAtem } from '../atem'
 import { AtemState, InvalidIdError } from '../state'
 import { IDeserializedCommand } from '../commands'
@@ -58,7 +57,7 @@ function createConnection(): BasicAtem {
 	})
 }
 
-function getChild(conn: BasicAtem): ThreadedClass<AtemSocketChildMock> {
+function getChild(conn: BasicAtem): AtemSocketChildMock {
 	return (conn as any).socket._socketProcess
 }
 
@@ -70,7 +69,7 @@ function runTest(name: string, filename: string): void {
 	describe(name, () => {
 		test(`Connection`, async () => {
 			const conn = createConnection()
-			await conn.connect('')
+			await conn.connect('127.0.0.1')
 
 			const child = getChild(conn)
 			expect(child).toBeTruthy()
@@ -114,6 +113,8 @@ function runTest(name: string, filename: string): void {
 			expect(state).toBeTruthy()
 
 			const state0 = state as AtemState
+
+			commands.length = 0
 
 			for (const cmd of commands) {
 				test(`${cmd.constructor.name}`, async () => {

--- a/src/atem.ts
+++ b/src/atem.ts
@@ -59,7 +59,6 @@ export interface AtemOptions {
 	address?: string
 	port?: number
 	debugBuffers?: boolean
-	/** @deprecated No longer user */ // nocommit: reimplement?
 	disableMultithreaded?: boolean
 	/** @deprecated No longer user */
 	childProcessTimeout?: number
@@ -109,6 +108,7 @@ export class BasicAtem extends EventEmitter<AtemEvents> {
 		this._status = AtemConnectionStatus.CLOSED
 		this.socket = new AtemSocket({
 			debugBuffers: options?.debugBuffers ?? false,
+			disableMultithreaded: options?.disableMultithreaded ?? false,
 			maxPacketSize: options?.maxPacketSize ?? DEFAULT_MAX_PACKET_SIZE,
 		})
 		this.dataTransferManager = new DT.DataTransferManager(this.sendCommands.bind(this))

--- a/src/atem.ts
+++ b/src/atem.ts
@@ -109,8 +109,6 @@ export class BasicAtem extends EventEmitter<AtemEvents> {
 		this._status = AtemConnectionStatus.CLOSED
 		this.socket = new AtemSocket({
 			debugBuffers: options?.debugBuffers ?? false,
-			address: options?.address || '',
-			port: options?.port || DEFAULT_PORT,
 			maxPacketSize: options?.maxPacketSize ?? DEFAULT_MAX_PACKET_SIZE,
 		})
 		this.dataTransferManager = new DT.DataTransferManager(this.sendCommands.bind(this))

--- a/src/atem.ts
+++ b/src/atem.ts
@@ -59,7 +59,9 @@ export interface AtemOptions {
 	address?: string
 	port?: number
 	debugBuffers?: boolean
+	/** @deprecated No longer user */ // nocommit: reimplement?
 	disableMultithreaded?: boolean
+	/** @deprecated No longer user */
 	childProcessTimeout?: number
 	/**
 	 * Maximum size of packets to transmit
@@ -109,8 +111,6 @@ export class BasicAtem extends EventEmitter<AtemEvents> {
 			debugBuffers: options?.debugBuffers ?? false,
 			address: options?.address || '',
 			port: options?.port || DEFAULT_PORT,
-			disableMultithreaded: options?.disableMultithreaded ?? false,
-			childProcessTimeout: options?.childProcessTimeout || 600,
 			maxPacketSize: options?.maxPacketSize ?? DEFAULT_MAX_PACKET_SIZE,
 		})
 		this.dataTransferManager = new DT.DataTransferManager(this.sendCommands.bind(this))

--- a/src/lib/__tests__/socket-child.spec.ts
+++ b/src/lib/__tests__/socket-child.spec.ts
@@ -37,8 +37,6 @@ function createSocketChild(
 ): AtemSocketChild {
 	return new AtemSocketChild(
 		{
-			address: ADDRESS,
-			port: DEFAULT_PORT,
 			debugBuffers: false,
 		},
 		onDisconnect || (async (): Promise<void> => Promise.resolve()),

--- a/src/lib/__tests__/socket-child.spec.ts
+++ b/src/lib/__tests__/socket-child.spec.ts
@@ -27,6 +27,7 @@ function fakeConnect(child: AtemSocketChild): void {
 	const child2 = child as any
 	child2._connectionState = ConnectionState.Established
 	child2._address = '127.0.0.1'
+	child2._port = 9910
 	child2.startTimers()
 }
 

--- a/src/lib/atemSocket.ts
+++ b/src/lib/atemSocket.ts
@@ -6,7 +6,7 @@ import { DEFAULT_PORT } from '../atem'
 import type { OutboundPacketInfo } from './atemSocketChild'
 import { PacketBuilder } from './packetBuilder'
 import * as Comlink from 'comlink'
-import { SocketWorkerApi } from './atemSocketChild2'
+import { SocketWorkerApi } from './atemSocketChildWrapper'
 import { Worker } from 'worker_threads'
 import nodeEndpoint from 'comlink/dist/umd/node-adapter'
 

--- a/src/lib/atemSocketChild.ts
+++ b/src/lib/atemSocketChild.ts
@@ -2,7 +2,7 @@
  * Note: this file wants as few imports as possible, as it gets loaded in a worker-thread and may require its own webpack bundle
  */
 import { createSocket, Socket, RemoteInfo } from 'dgram'
-import * as NanoTimer from 'nanotimer'
+import NanoTimer from 'nanotimer'
 import { performance } from 'perf_hooks'
 
 const IN_FLIGHT_TIMEOUT = 60 // ms
@@ -180,6 +180,10 @@ export class AtemSocketChild {
 	}
 
 	private sendPacket(payloadLength: number, payloadHex: string, trackingId: number): void {
+		if (this._connectionState == ConnectionState.Disconnected) {
+			throw new Error('Socket is disconnected')
+		}
+
 		const packetId = this._nextSendPacketId++
 		if (this._nextSendPacketId >= MAX_PACKET_ID) this._nextSendPacketId = 0
 

--- a/src/lib/atemSocketChild.ts
+++ b/src/lib/atemSocketChild.ts
@@ -58,8 +58,8 @@ export class AtemSocketChild {
 	private _nextSendPacketId = 1
 	private _sessionId = 0
 
-	private _address: string
-	private _port: number
+	private _address: string | undefined
+	private _port: number | undefined
 	private _socket: Socket
 
 	private _lastReceivedAt: number = performance.now()
@@ -75,15 +75,13 @@ export class AtemSocketChild {
 	private readonly onPacketsAcknowledged: (ids: Array<{ packetId: number; trackingId: number }>) => Promise<void>
 
 	constructor(
-		options: { address: string; port: number; debugBuffers: boolean },
+		options: { debugBuffers: boolean },
 		onDisconnect: () => Promise<void>,
 		onLog: (message: string) => Promise<void>,
 		onCommandReceived: (payload: Buffer, packetId: number) => Promise<void>,
 		onCommandAcknowledged: (ids: Array<{ packetId: number; trackingId: number }>) => Promise<void>
 	) {
 		this._debugBuffers = options.debugBuffers
-		this._address = options.address
-		this._port = options.port
 
 		this.onDisconnect = onDisconnect
 		this.onLog = onLog
@@ -323,6 +321,7 @@ export class AtemSocketChild {
 	}
 
 	private _sendPacket(packet: Buffer): void {
+		if (!this._address || !this._port) throw new Error('Missing address or port')
 		if (this._debugBuffers) this.log(`SEND ${packet.toString('hex')}`)
 		this._socket.send(packet, 0, packet.length, this._port, this._address)
 	}

--- a/src/lib/atemSocketChild2.ts
+++ b/src/lib/atemSocketChild2.ts
@@ -6,19 +6,18 @@ import { AtemSocketChild, OutboundPacketInfo } from './atemSocketChild'
 if (!parentPort) {
 	throw new Error('InvalidWorker')
 }
-
-export interface InitData {
-	debugBuffers: boolean
-	onDisconnect: () => Promise<void>
-	onLog: (message: string) => Promise<void>
-	onCommandsReceived: (payload: Buffer) => Promise<void>
-	onPacketsAcknowledged: (ids: Array<{ packetId: number; trackingId: number }>) => Promise<void>
-}
+parentPort.setMaxListeners(100)
 
 export class Api {
 	private tempChild: AtemSocketChild | undefined
 
-	public init({ debugBuffers, onDisconnect, onLog, onCommandsReceived, onPacketsAcknowledged }: InitData): void {
+	public init(
+		debugBuffers: boolean,
+		onDisconnect: () => Promise<void>,
+		onLog: (message: string) => Promise<void>,
+		onCommandsReceived: (payload: Buffer) => Promise<void>,
+		onPacketsAcknowledged: (ids: Array<{ packetId: number; trackingId: number }>) => Promise<void>
+	): void {
 		if (this.tempChild) throw new Error('Already initialised!')
 
 		this.tempChild = new AtemSocketChild(
@@ -50,13 +49,5 @@ export class Api {
 		this.tempChild.sendPackets(packets)
 	}
 }
-
-setInterval(() => {
-	console.log('im alive')
-}, 1000)
-
-setTimeout(() => {
-	process.exit(1)
-}, 5000)
 
 comlink.expose(new Api(), nodeEndpoint(parentPort))

--- a/src/lib/atemSocketChild2.ts
+++ b/src/lib/atemSocketChild2.ts
@@ -1,23 +1,15 @@
-import { parentPort } from 'worker_threads'
-import * as comlink from 'comlink'
-import nodeEndpoint from 'comlink/dist/umd/node-adapter'
 import { AtemSocketChild, OutboundPacketInfo } from './atemSocketChild'
 
-if (!parentPort) {
-	throw new Error('InvalidWorker')
-}
-parentPort.setMaxListeners(100)
-
-export class Api {
+export class SocketWorkerApi {
 	private tempChild: AtemSocketChild | undefined
 
-	public init(
+	public async init(
 		debugBuffers: boolean,
 		onDisconnect: () => Promise<void>,
 		onLog: (message: string) => Promise<void>,
 		onCommandsReceived: (payload: Buffer) => Promise<void>,
 		onPacketsAcknowledged: (ids: Array<{ packetId: number; trackingId: number }>) => Promise<void>
-	): void {
+	): Promise<void> {
 		if (this.tempChild) throw new Error('Already initialised!')
 
 		this.tempChild = new AtemSocketChild(
@@ -49,5 +41,3 @@ export class Api {
 		this.tempChild.sendPackets(packets)
 	}
 }
-
-comlink.expose(new Api(), nodeEndpoint(parentPort))

--- a/src/lib/atemSocketChild2.ts
+++ b/src/lib/atemSocketChild2.ts
@@ -1,0 +1,64 @@
+import { parentPort } from 'worker_threads'
+import * as comlink from 'comlink'
+import nodeEndpoint from 'comlink/dist/umd/node-adapter'
+import { AtemSocketChild, OutboundPacketInfo } from './atemSocketChild'
+
+if (!parentPort) {
+	throw new Error('InvalidWorker')
+}
+
+export interface InitData {
+	debugBuffers: boolean
+	onDisconnect: () => Promise<void>
+	onLog: (message: string) => Promise<void>
+	onCommandsReceived: (payload: Buffer) => Promise<void>
+	onPacketsAcknowledged: (ids: Array<{ packetId: number; trackingId: number }>) => Promise<void>
+}
+
+export class Api {
+	private tempChild: AtemSocketChild | undefined
+
+	public init({ debugBuffers, onDisconnect, onLog, onCommandsReceived, onPacketsAcknowledged }: InitData): void {
+		if (this.tempChild) throw new Error('Already initialised!')
+
+		this.tempChild = new AtemSocketChild(
+			{
+				address: '127.0.0.1', // TODO - remove?
+				port: 9910,
+				debugBuffers,
+			},
+			onDisconnect,
+			onLog,
+			onCommandsReceived,
+			onPacketsAcknowledged
+		)
+	}
+
+	public async connect(address: string, port: number): Promise<void> {
+		if (!this.tempChild) throw new Error('Not initialised!')
+
+		await this.tempChild.connect(address, port)
+	}
+
+	public async disconnect(): Promise<void> {
+		if (!this.tempChild) throw new Error('Not initialised!')
+
+		await this.tempChild.disconnect()
+	}
+
+	public async sendPackets(packets: OutboundPacketInfo[]): Promise<void> {
+		if (!this.tempChild) throw new Error('Not initialised!')
+
+		this.tempChild.sendPackets(packets)
+	}
+}
+
+setInterval(() => {
+	console.log('im alive')
+}, 1000)
+
+setTimeout(() => {
+	process.exit(1)
+}, 5000)
+
+comlink.expose(new Api(), nodeEndpoint(parentPort))

--- a/src/lib/atemSocketChild2.ts
+++ b/src/lib/atemSocketChild2.ts
@@ -23,8 +23,6 @@ export class Api {
 
 		this.tempChild = new AtemSocketChild(
 			{
-				address: '127.0.0.1', // TODO - remove?
-				port: 9910,
 				debugBuffers,
 			},
 			onDisconnect,

--- a/src/lib/atemSocketChildWrapper.ts
+++ b/src/lib/atemSocketChildWrapper.ts
@@ -1,7 +1,7 @@
 import { AtemSocketChild, OutboundPacketInfo } from './atemSocketChild'
 
 export class SocketWorkerApi {
-	private tempChild: AtemSocketChild | undefined
+	private wrappedChild: AtemSocketChild | undefined
 
 	public async init(
 		debugBuffers: boolean,
@@ -10,9 +10,9 @@ export class SocketWorkerApi {
 		onCommandsReceived: (payload: Buffer) => Promise<void>,
 		onPacketsAcknowledged: (ids: Array<{ packetId: number; trackingId: number }>) => Promise<void>
 	): Promise<void> {
-		if (this.tempChild) throw new Error('Already initialised!')
+		if (this.wrappedChild) throw new Error('Already initialised!')
 
-		this.tempChild = new AtemSocketChild(
+		this.wrappedChild = new AtemSocketChild(
 			{
 				debugBuffers,
 			},
@@ -24,20 +24,20 @@ export class SocketWorkerApi {
 	}
 
 	public async connect(address: string, port: number): Promise<void> {
-		if (!this.tempChild) throw new Error('Not initialised!')
+		if (!this.wrappedChild) throw new Error('Not initialised!')
 
-		await this.tempChild.connect(address, port)
+		await this.wrappedChild.connect(address, port)
 	}
 
 	public async disconnect(): Promise<void> {
-		if (!this.tempChild) throw new Error('Not initialised!')
+		if (!this.wrappedChild) throw new Error('Not initialised!')
 
-		await this.tempChild.disconnect()
+		await this.wrappedChild.disconnect()
 	}
 
 	public async sendPackets(packets: OutboundPacketInfo[]): Promise<void> {
-		if (!this.tempChild) throw new Error('Not initialised!')
+		if (!this.wrappedChild) throw new Error('Not initialised!')
 
-		this.tempChild.sendPackets(packets)
+		this.wrappedChild.sendPackets(packets)
 	}
 }

--- a/src/lib/socket-worker.ts
+++ b/src/lib/socket-worker.ts
@@ -1,7 +1,7 @@
 import { parentPort } from 'worker_threads'
 import * as comlink from 'comlink'
 import nodeEndpoint from 'comlink/dist/umd/node-adapter'
-import { SocketWorkerApi } from './atemSocketChild2'
+import { SocketWorkerApi } from './atemSocketChildWrapper'
 
 if (!parentPort) {
 	throw new Error('InvalidWorker')

--- a/src/lib/socket-worker.ts
+++ b/src/lib/socket-worker.ts
@@ -1,0 +1,10 @@
+import { parentPort } from 'worker_threads'
+import * as comlink from 'comlink'
+import nodeEndpoint from 'comlink/dist/umd/node-adapter'
+import { SocketWorkerApi } from './atemSocketChild2'
+
+if (!parentPort) {
+	throw new Error('InvalidWorker')
+}
+
+comlink.expose(new SocketWorkerApi(), nodeEndpoint(parentPort))

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -9,6 +9,8 @@
 			"*": ["./node_modules/*"],
 			"atem-connection": ["./src/index.ts"]
 		},
-		"types": ["node"]
+		"types": ["node"],
+		"esModuleInterop": true,
+		"skipLibCheck": true
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1772,7 +1772,6 @@ __metadata:
     pinst: ^3.0.0
     rimraf: ^5.0.5
     sinon: ^14.0.2
-    threadedclass: ^1.2.1
     ts-jest: ^29.1.1
     ts-node: ^10.9.1
     tslib: ^2.6.2
@@ -2010,7 +2009,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"callsites@npm:^3.0.0, callsites@npm:^3.1.0":
+"callsites@npm:^3.0.0":
   version: 3.1.0
   resolution: "callsites@npm:3.1.0"
   checksum: 072d17b6abb459c2ba96598918b55868af677154bec7e73d222ef95a8fdb9bbf7dae96a8421085cdad8cd190d86653b5b6dc55a4484f2e5b2e27d5e0c3fc15b3
@@ -3603,13 +3602,6 @@ __metadata:
   version: 1.1.0
   resolution: "is-plain-obj@npm:1.1.0"
   checksum: 0ee04807797aad50859652a7467481816cbb57e5cc97d813a7dcd8915da8195dc68c436010bf39d195226cde6a2d352f4b815f16f26b7bf486a5754290629931
-  languageName: node
-  linkType: hard
-
-"is-running@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "is-running@npm:2.1.0"
-  checksum: b8804a041e532d218b123ddd34e1b5ff086ba03d100373dfda99179569b3fd146de228bef65d7448be4c4dfae3df84d9aa45b1e1b4a044899fc0521c68e32692
   languageName: node
   linkType: hard
 
@@ -6249,18 +6241,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"threadedclass@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "threadedclass@npm:1.2.1"
-  dependencies:
-    callsites: ^3.1.0
-    eventemitter3: ^4.0.4
-    is-running: ^2.1.0
-    tslib: ^1.13.0
-  checksum: 2f9cab0df9ed21865f6f874ff7e352bbc32c9970bb48f132ae9bd71d9203655089ad065fa8438bdb786e381c3e0284b43bf7f281ad607962ab365781ea9aef6f
-  languageName: node
-  linkType: hard
-
 "through@npm:^2.3.8":
   version: 2.3.8
   resolution: "through@npm:2.3.8"
@@ -6393,7 +6373,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.13.0, tslib@npm:^1.8.1":
+"tslib@npm:^1.8.1":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd

--- a/yarn.lock
+++ b/yarn.lock
@@ -1758,6 +1758,7 @@ __metadata:
     "@types/object-path": ^0.11.4
     "@types/sinon": ^10.0.20
     "@types/sinonjs__fake-timers": ^8.1.5
+    comlink: ^4.4.1
     debug: ^4.3.4
     eventemitter3: ^4.0.7
     exit-hook: ^2.2.1
@@ -2218,6 +2219,13 @@ __metadata:
   version: 2.0.20
   resolution: "colorette@npm:2.0.20"
   checksum: 0c016fea2b91b733eb9f4bcdb580018f52c0bc0979443dad930e5037a968237ac53d9beb98e218d2e9235834f8eebce7f8e080422d6194e957454255bde71d3d
+  languageName: node
+  linkType: hard
+
+"comlink@npm:^4.4.1":
+  version: 4.4.1
+  resolution: "comlink@npm:4.4.1"
+  checksum: 16d58a8f590087fc45432e31d6c138308dfd4b75b89aec0b7f7bb97ad33d810381bd2b1e608a1fb2cf05979af9cbfcdcaf1715996d5fcf77aeb013b6da3260af
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1758,7 +1758,7 @@ __metadata:
     "@types/object-path": ^0.11.4
     "@types/sinon": ^10.0.20
     "@types/sinonjs__fake-timers": ^8.1.5
-    comlink: ^4.4.1
+    comlink: "npm:@superflytv/comlink@^4.4.2"
     debug: ^4.3.4
     eventemitter3: ^4.0.7
     exit-hook: ^2.2.1
@@ -2222,10 +2222,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"comlink@npm:^4.4.1":
-  version: 4.4.1
-  resolution: "comlink@npm:4.4.1"
-  checksum: 16d58a8f590087fc45432e31d6c138308dfd4b75b89aec0b7f7bb97ad33d810381bd2b1e608a1fb2cf05979af9cbfcdcaf1715996d5fcf77aeb013b6da3260af
+"comlink@npm:@superflytv/comlink@^4.4.2":
+  version: 4.4.2
+  resolution: "@superflytv/comlink@npm:4.4.2"
+  checksum: 5bfc8fbb9ef9a7055322074f2519e5c5820714af7aa7dda707c57b7a669e837b669097681c50ce558828e01810c2629b4adddaaf25d5d4856d456c83a349b494
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
This pull request is posted on behalf of myself


## Type of Contribution

This is a:  Code improvement 

## Current Behavior

We use threadedClass for managing the worker_thread used to run the connection.
This library was developed internally at superfly, and so is not very popular and has a few rough corners.



## New Behavior
Use the [comlink](https://www.npmjs.com/package/comlink) library instead. This is a simpler and smaller library, and while it looks to be lacking a bit in maintenance recently, its much higher popularity means it will likely be possible to jump to a fork which 'wins'. But also its popularity shows that maybe it is stable and good enough as it is.

Additionally, the way this library loads the worker code means it should play better with webpack, which will resolve some issues that have been reported

## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->

This has not been tested much yet, 

Known issues:
- [ ] The `socket-worker` file should be named better, as it needs to be its own file on disk when bundled with webpack. naming it something to clarify its from atem-connection specific should be enough.
- [ ] If the worker thread exits, or fails to start, promises fail to resolve. 


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [ ] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
