### PR TITLE
feat: batching api

### DIFF
--- a/src/atem.ts
+++ b/src/atem.ts
@@ -1,48 +1,13 @@
-import { EventEmitter } from 'eventemitter3'
-import { AtemState, AtemStateUtil, InvalidIdError, ColorGeneratorState } from './state'
+import * as EventEmitter from 'eventemitter3'
+import { AtemState, AtemStateUtil, InvalidIdError } from './state'
 import { AtemSocket } from './lib/atemSocket'
 import { ISerializableCommand, IDeserializedCommand } from './commands/CommandBase'
 import * as Commands from './commands'
 import * as DataTransferCommands from './commands/DataTransfer'
-import { MediaPlayer, MediaPlayerSource } from './state/media'
-import {
-	DipTransitionSettings,
-	DVETransitionSettings,
-	MixTransitionSettings,
-	StingerTransitionSettings,
-	SuperSource,
-	TransitionProperties,
-	WipeTransitionSettings,
-} from './state/video'
-import * as USK from './state/video/upstreamKeyers'
-import { InputChannel } from './state/input'
-import { DownstreamKeyerGeneral, DownstreamKeyerMask } from './state/video/downstreamKeyers'
 import * as DT from './dataTransfer'
 import * as Util from './lib/atemUtil'
 import { VideoModeInfo, getVideoModeInfo } from './lib/videoMode'
-import * as Enums from './enums'
-import {
-	ClassicAudioMonitorChannel,
-	ClassicAudioMasterChannel,
-	ClassicAudioChannel,
-	ClassicAudioHeadphoneOutputChannel,
-} from './state/audio'
 import { listVisibleInputs } from './lib/tally'
-import { RecordingStateProperties } from './state/recording'
-import { OmitReadonly } from './lib/types'
-import { StreamingServiceProperties } from './state/streaming'
-import {
-	FairlightAudioMonitorChannel,
-	FairlightAudioCompressorState,
-	FairlightAudioLimiterState,
-	FairlightAudioEqualizerBandState,
-	FairlightAudioExpanderState,
-	FairlightAudioRoutingSource,
-	FairlightAudioRoutingOutput,
-	FairlightAudioMonitorSolo,
-} from './state/fairlight'
-import { FairlightDynamicsResetProps } from './commands/Fairlight/common'
-import { MultiViewerPropertiesState } from './state/settings'
 import {
 	calculateGenerateMultiviewerLabelProps,
 	generateMultiviewerLabel,
@@ -58,6 +23,8 @@ import { generateUploadBufferInfo, UploadBufferInfo } from './dataTransfer/dataT
 import { convertWAVToRaw } from './lib/converters/wavAudio'
 import { decodeRLE } from './lib/converters/rle'
 import { convertYUV422ToRGBA } from './lib/converters/yuv422ToRgba'
+import { AtemCommandSender } from './lib/atemCommands'
+import * as Enums from './enums'
 
 export interface AtemOptions {
 	address?: string
@@ -97,16 +64,33 @@ export enum AtemConnectionStatus {
 export const DEFAULT_PORT = 9910
 export const DEFAULT_MAX_PACKET_SIZE = 1416 // Matching ATEM software
 
-export class BasicAtem extends EventEmitter<AtemEvents> {
+export interface IBasicAtem {
+	get status(): AtemConnectionStatus
+	get state(): Readonly<AtemState> | undefined
+
+	/**
+	 * Get the current videomode of the ATEM, if known
+	 */
+	get videoMode(): Readonly<VideoModeInfo> | undefined
+
+	connect(address: string, port?: number): Promise<void>
+	disconnect(): Promise<void>
+	destroy(): Promise<void>
+
+	sendCommands(commands: ISerializableCommand[]): Promise<void>
+	sendCommand(command: ISerializableCommand): Promise<void>
+}
+
+class AtemWrapper {
+	private readonly emitter: EventEmitter<AtemEvents>
 	private readonly socket: AtemSocket
-	protected readonly dataTransferManager: DT.DataTransferManager
+	public readonly dataTransferManager: DT.DataTransferManager // TODO - this should be protected/private but we need to access it from the Atem class
 	private _state: AtemState | undefined
 	private _sentQueue: { [packetId: string]: SentPackets } = {}
 	private _status: AtemConnectionStatus
 
-	constructor(options?: AtemOptions) {
-		super()
-
+	constructor(emitter: EventEmitter<AtemEvents>, options: AtemOptions) {
+		this.emitter = emitter
 		this._state = AtemStateUtil.Create()
 		this._status = AtemConnectionStatus.CLOSED
 		this.socket = new AtemSocket({
@@ -120,25 +104,25 @@ export class BasicAtem extends EventEmitter<AtemEvents> {
 		this.dataTransferManager = new DT.DataTransferManager(this.sendCommands.bind(this))
 
 		this.socket.on('receivedCommands', (commands) => {
-			this.emit('receivedCommands', commands)
+			this.emitter.emit('receivedCommands', commands)
 			this._mutateState(commands)
 		})
 		this.socket.on('ackPackets', (trackingIds) => this._resolveCommands(trackingIds))
-		this.socket.on('info', (msg) => this.emit('info', msg))
-		this.socket.on('debug', (msg) => this.emit('debug', msg))
-		this.socket.on('error', (e) => this.emit('error', e))
+		this.socket.on('info', (msg) => this.emitter.emit('info', msg))
+		this.socket.on('debug', (msg) => this.emitter.emit('debug', msg))
+		this.socket.on('error', (e) => this.emitter.emit('error', e))
 		this.socket.on('disconnect', () => {
 			this._status = AtemConnectionStatus.CLOSED
 			this.dataTransferManager.stopCommandSending()
 			this._rejectAllCommands()
-			this.emit('disconnected')
+			this.emitter.emit('disconnected')
 			this._state = undefined
 		})
 	}
 
 	private _onInitComplete(): void {
 		this.dataTransferManager.startCommandSending()
-		this.emit('connected')
+		this.emitter.emit('connected')
 	}
 
 	get status(): AtemConnectionStatus {
@@ -190,10 +174,6 @@ export class BasicAtem extends EventEmitter<AtemEvents> {
 		await Promise.allSettled(promises)
 	}
 
-	public async sendCommand(command: ISerializableCommand): Promise<void> {
-		return await this.sendCommands([command])
-	}
-
 	private _mutateState(commands: IDeserializedCommand[]): void {
 		// Is this the start of a new connection?
 		if (commands.find((cmd) => cmd instanceof Commands.VersionCommand)) {
@@ -207,15 +187,15 @@ export class BasicAtem extends EventEmitter<AtemEvents> {
 		const state = this._state
 		for (const command of commands) {
 			if (command instanceof TimeCommand) {
-				this.emit('updatedTime', command.properties)
+				this.emitter.emit('updatedTime', command.properties)
 			} else if (command instanceof Commands.FairlightMixerMasterLevelsUpdateCommand) {
-				this.emit('levelChanged', {
+				this.emitter.emit('levelChanged', {
 					system: 'fairlight',
 					type: 'master',
 					levels: command.properties,
 				})
 			} else if (command instanceof Commands.FairlightMixerSourceLevelsUpdateCommand) {
-				this.emit('levelChanged', {
+				this.emitter.emit('levelChanged', {
 					system: 'fairlight',
 					type: 'source',
 					source: command.source,
@@ -232,14 +212,14 @@ export class BasicAtem extends EventEmitter<AtemEvents> {
 					}
 				} catch (e) {
 					if (e instanceof InvalidIdError) {
-						this.emit(
+						this.emitter.emit(
 							'debug',
 							`Invalid command id: ${e}. Command: ${command.constructor.name} ${Util.commandStringify(
 								command
 							)}`
 						)
 					} else {
-						this.emit(
+						this.emitter.emit(
 							'error',
 							`MutateState failed: ${e}. Command: ${command.constructor.name} ${Util.commandStringify(
 								command
@@ -262,7 +242,7 @@ export class BasicAtem extends EventEmitter<AtemEvents> {
 			this._status = AtemConnectionStatus.CONNECTED
 			this._onInitComplete()
 		} else if (state && this._status === AtemConnectionStatus.CONNECTED && allChangedPaths.length > 0) {
-			this.emit('stateChanged', state, allChangedPaths)
+			this.emitter.emit('stateChanged', state, allChangedPaths)
 		}
 	}
 
@@ -285,16 +265,105 @@ export class BasicAtem extends EventEmitter<AtemEvents> {
 	}
 }
 
-export class Atem extends BasicAtem {
+export class BasicAtem extends EventEmitter<AtemEvents> implements IBasicAtem {
+	readonly #client: AtemWrapper
+
+	constructor(options?: AtemOptions) {
+		super()
+
+		this.#client = new AtemWrapper(this, options || {})
+	}
+
+	get status(): AtemConnectionStatus {
+		return this.#client.status
+	}
+
+	get state(): Readonly<AtemState> | undefined {
+		return this.#client.state
+	}
+
+	/**
+	 * Get the current videomode of the ATEM, if known
+	 */
+	get videoMode(): Readonly<VideoModeInfo> | undefined {
+		return this.#client.videoMode
+	}
+
+	public async connect(address: string, port?: number): Promise<void> {
+		return this.#client.connect(address, port)
+	}
+
+	public async disconnect(): Promise<void> {
+		return this.#client.disconnect()
+	}
+
+	public async destroy(): Promise<void> {
+		return this.#client.destroy()
+	}
+
+	public async sendCommands(commands: ISerializableCommand[]): Promise<void> {
+		return this.#client.sendCommands(commands)
+	}
+
+	public async sendCommand(command: ISerializableCommand): Promise<void> {
+		return this.#client.sendCommands([command])
+	}
+}
+
+export class Atem extends AtemCommandSender<Promise<void>> implements EventEmitter<AtemEvents>, IBasicAtem {
+	readonly #client: AtemWrapper
+	readonly #events = new EventEmitter<AtemEvents>()
+
 	#multiviewerFontFace: Promise<FontFace>
 	#multiviewerFontScale: number
 
+	protected get apiVersion(): Enums.ProtocolVersion | undefined {
+		return this.#client.state?.info?.apiVersion
+	}
+
 	constructor(options?: AtemOptions) {
-		super(options)
+		super()
+
+		this.#client = new AtemWrapper(this.#events, options || {})
 
 		this.#multiviewerFontFace = PLazy.from(async () => loadFont())
 		this.#multiviewerFontScale = 1.0
 	}
+
+	/** @begin IBasicAtem */
+
+	get status(): AtemConnectionStatus {
+		return this.#client.status
+	}
+	get state(): Readonly<AtemState> | undefined {
+		return this.#client.state
+	}
+
+	/**
+	 * Get the current videomode of the ATEM, if known
+	 */
+	get videoMode(): Readonly<VideoModeInfo> | undefined {
+		return this.#client.videoMode
+	}
+
+	async connect(address: string, port?: number): Promise<void> {
+		return this.#client.connect(address, port)
+	}
+	async disconnect(): Promise<void> {
+		return this.#client.disconnect()
+	}
+	async destroy(): Promise<void> {
+		return this.#client.destroy()
+	}
+
+	async sendCommands(commands: ISerializableCommand[]): Promise<void> {
+		return this.#client.sendCommands(commands)
+	}
+	async sendCommand(command: ISerializableCommand): Promise<void> {
+		return this.#client.sendCommands([command])
+	}
+
+	/** @end IBasicAtem */
 
 	/**
 	 * Set the font to use for the multiviewer, or reset to default
@@ -325,447 +394,11 @@ export class Atem extends BasicAtem {
 		}
 	}
 
-	public async changeProgramInput(input: number, me = 0): Promise<void> {
-		const command = new Commands.ProgramInputCommand(me, input)
-		return this.sendCommand(command)
-	}
-
-	public async changePreviewInput(input: number, me = 0): Promise<void> {
-		const command = new Commands.PreviewInputCommand(me, input)
-		return this.sendCommand(command)
-	}
-
-	public async cut(me = 0): Promise<void> {
-		const command = new Commands.CutCommand(me)
-		return this.sendCommand(command)
-	}
-
-	public async autoTransition(me = 0): Promise<void> {
-		const command = new Commands.AutoTransitionCommand(me)
-		return this.sendCommand(command)
-	}
-
-	public async fadeToBlack(me = 0): Promise<void> {
-		const command = new Commands.FadeToBlackAutoCommand(me)
-		return this.sendCommand(command)
-	}
-
-	public async setFadeToBlackRate(rate: number, me = 0): Promise<void> {
-		const command = new Commands.FadeToBlackRateCommand(me, rate)
-		return this.sendCommand(command)
-	}
-
-	public async autoDownstreamKey(key = 0, isTowardsOnAir?: boolean): Promise<void> {
-		const command = new Commands.DownstreamKeyAutoCommand(key)
-		command.updateProps({ isTowardsOnAir })
-		return this.sendCommand(command)
-	}
-
-	public async setDipTransitionSettings(newProps: Partial<DipTransitionSettings>, me = 0): Promise<void> {
-		const command = new Commands.TransitionDipCommand(me)
-		command.updateProps(newProps)
-		return this.sendCommand(command)
-	}
-
-	public async setDVETransitionSettings(newProps: Partial<DVETransitionSettings>, me = 0): Promise<void> {
-		const command = new Commands.TransitionDVECommand(me)
-		command.updateProps(newProps)
-		return this.sendCommand(command)
-	}
-
-	public async setMixTransitionSettings(newProps: Pick<MixTransitionSettings, 'rate'>, me = 0): Promise<void> {
-		const command = new Commands.TransitionMixCommand(me, newProps.rate)
-		return this.sendCommand(command)
-	}
-
-	public async setTransitionPosition(position: number, me = 0): Promise<void> {
-		const command = new Commands.TransitionPositionCommand(me, position)
-		return this.sendCommand(command)
-	}
-
-	public async previewTransition(on: boolean, me = 0): Promise<void> {
-		const command = new Commands.PreviewTransitionCommand(me, on)
-		return this.sendCommand(command)
-	}
-
-	public async setTransitionStyle(newProps: Partial<OmitReadonly<TransitionProperties>>, me = 0): Promise<void> {
-		const command = new Commands.TransitionPropertiesCommand(me)
-		command.updateProps(newProps)
-		return this.sendCommand(command)
-	}
-
-	public async setStingerTransitionSettings(newProps: Partial<StingerTransitionSettings>, me = 0): Promise<void> {
-		const command = new Commands.TransitionStingerCommand(me)
-		command.updateProps(newProps)
-		return this.sendCommand(command)
-	}
-
-	public async setWipeTransitionSettings(newProps: Partial<WipeTransitionSettings>, me = 0): Promise<void> {
-		const command = new Commands.TransitionWipeCommand(me)
-		command.updateProps(newProps)
-		return this.sendCommand(command)
-	}
-
-	public async setAuxSource(source: number, bus = 0): Promise<void> {
-		const command = new Commands.AuxSourceCommand(bus, source)
-		return this.sendCommand(command)
-	}
-
-	public async setDownstreamKeyTie(tie: boolean, key = 0): Promise<void> {
-		const command = new Commands.DownstreamKeyTieCommand(key, tie)
-		return this.sendCommand(command)
-	}
-
-	public async setDownstreamKeyOnAir(onAir: boolean, key = 0): Promise<void> {
-		const command = new Commands.DownstreamKeyOnAirCommand(key, onAir)
-		return this.sendCommand(command)
-	}
-
-	public async setDownstreamKeyCutSource(input: number, key = 0): Promise<void> {
-		const command = new Commands.DownstreamKeyCutSourceCommand(key, input)
-		return this.sendCommand(command)
-	}
-
-	public async setDownstreamKeyFillSource(input: number, key = 0): Promise<void> {
-		const command = new Commands.DownstreamKeyFillSourceCommand(key, input)
-		return this.sendCommand(command)
-	}
-
-	public async setDownstreamKeyGeneralProperties(props: Partial<DownstreamKeyerGeneral>, key = 0): Promise<void> {
-		const command = new Commands.DownstreamKeyGeneralCommand(key)
-		command.updateProps(props)
-		return this.sendCommand(command)
-	}
-
-	public async setDownstreamKeyMaskSettings(props: Partial<DownstreamKeyerMask>, key = 0): Promise<void> {
-		const command = new Commands.DownstreamKeyMaskCommand(key)
-		command.updateProps(props)
-		return this.sendCommand(command)
-	}
-
-	public async setDownstreamKeyRate(rate: number, key = 0): Promise<void> {
-		const command = new Commands.DownstreamKeyRateCommand(key, rate)
-		return this.sendCommand(command)
-	}
-
-	public async setTime(hour: number, minute: number, second: number, frame: number): Promise<void> {
-		const command = new Commands.TimeCommand({ hour, minute, second, frame })
-		return this.sendCommand(command)
-	}
-
-	public async setTimeMode(mode: Enums.TimeMode): Promise<void> {
-		const command = new Commands.TimeConfigCommand(mode)
-		return this.sendCommand(command)
-	}
-
-	public async requestTime(): Promise<void> {
-		const command = new Commands.TimeRequestCommand()
-		return this.sendCommand(command)
-	}
-
-	public async macroContinue(): Promise<void> {
-		const command = new Commands.MacroActionCommand(0, Enums.MacroAction.Continue)
-		return this.sendCommand(command)
-	}
-
-	public async macroDelete(index = 0): Promise<void> {
-		const command = new Commands.MacroActionCommand(index, Enums.MacroAction.Delete)
-		return this.sendCommand(command)
-	}
-
-	public async macroInsertUserWait(): Promise<void> {
-		const command = new Commands.MacroActionCommand(0, Enums.MacroAction.InsertUserWait)
-		return this.sendCommand(command)
-	}
-
-	public async macroInsertTimedWait(frames: number): Promise<void> {
-		const command = new Commands.MacroAddTimedPauseCommand(frames)
-		return this.sendCommand(command)
-	}
-
-	public async macroRun(index = 0): Promise<void> {
-		const command = new Commands.MacroActionCommand(index, Enums.MacroAction.Run)
-		return this.sendCommand(command)
-	}
-
-	public async macroStop(): Promise<void> {
-		const command = new Commands.MacroActionCommand(0, Enums.MacroAction.Stop)
-		return this.sendCommand(command)
-	}
-
-	public async macroStartRecord(index: number, name: string, description: string): Promise<void> {
-		const command = new Commands.MacroRecordCommand(index, name, description)
-		return this.sendCommand(command)
-	}
-
-	public async macroStopRecord(): Promise<void> {
-		const command = new Commands.MacroActionCommand(0, Enums.MacroAction.StopRecord)
-		return this.sendCommand(command)
-	}
-
-	public async macroUpdateProperties(props: Commands.MacroPropertiesCommand['properties'], index = 0): Promise<void> {
-		const command = new Commands.MacroPropertiesCommand(index)
-		command.updateProps(props)
-		return this.sendCommand(command)
-	}
-
-	public async macroSetLoop(loop: boolean): Promise<void> {
-		const command = new Commands.MacroRunStatusCommand()
-		command.updateProps({ loop })
-		return this.sendCommand(command)
-	}
-
 	public async downloadMacro(index: number): Promise<Buffer> {
-		return this.dataTransferManager.downloadMacro(index)
+		return this.#client.dataTransferManager.downloadMacro(index)
 	}
 	public async uploadMacro(index: number, name: string, data: Buffer): Promise<void> {
-		return this.dataTransferManager.uploadMacro(index, data, name)
-	}
-
-	public async setMultiViewerWindowSource(source: number, mv = 0, window = 0): Promise<void> {
-		const command = new Commands.MultiViewerSourceCommand(mv, window, source)
-		return this.sendCommand(command)
-	}
-	public async setMultiViewerWindowSafeAreaEnabled(safeAreaEnabled: boolean, mv = 0, window = 0): Promise<void> {
-		const command = new Commands.MultiViewerWindowSafeAreaCommand(mv, window, safeAreaEnabled)
-		return this.sendCommand(command)
-	}
-	public async setMultiViewerWindowVuEnabled(vuEnabled: boolean, mv = 0, window = 0): Promise<void> {
-		const command = new Commands.MultiViewerWindowVuMeterCommand(mv, window, vuEnabled)
-		return this.sendCommand(command)
-	}
-
-	public async setMultiViewerVuOpacity(opacity: number, mv = 0): Promise<void> {
-		const command = new Commands.MultiViewerVuOpacityCommand(mv, opacity)
-		return this.sendCommand(command)
-	}
-	public async setMultiViewerProperties(props: Partial<MultiViewerPropertiesState>, mv = 0): Promise<void> {
-		const command = new Commands.MultiViewerPropertiesCommand(mv)
-		command.updateProps(props)
-		return this.sendCommand(command)
-	}
-
-	public async setColorGeneratorColour(newProps: Partial<ColorGeneratorState>, index = 0): Promise<void> {
-		const command = new Commands.ColorGeneratorCommand(index)
-		command.updateProps(newProps)
-		return this.sendCommand(command)
-	}
-
-	public async setMediaPlayerSettings(newProps: Partial<MediaPlayer>, player = 0): Promise<void> {
-		const command = new Commands.MediaPlayerStatusCommand(player)
-		command.updateProps(newProps)
-		return this.sendCommand(command)
-	}
-
-	public async setMediaPlayerSource(newProps: Partial<MediaPlayerSource>, player = 0): Promise<void> {
-		const command = new Commands.MediaPlayerSourceCommand(player)
-		command.updateProps(newProps)
-		return this.sendCommand(command)
-	}
-
-	public async setMediaClip(index: number, name: string, frames = 1): Promise<void> {
-		const command = new Commands.MediaPoolSetClipCommand({ index, name, frames })
-		return this.sendCommand(command)
-	}
-
-	public async clearMediaPoolClip(clipId: number): Promise<void> {
-		const command = new Commands.MediaPoolClearClipCommand(clipId)
-		return this.sendCommand(command)
-	}
-
-	public async clearMediaPoolStill(stillId: number): Promise<void> {
-		const command = new Commands.MediaPoolClearStillCommand(stillId)
-		return this.sendCommand(command)
-	}
-
-	public async captureMediaPoolStill(): Promise<void> {
-		const command = new Commands.MediaPoolCaptureStillCommand()
-		return this.sendCommand(command)
-	}
-
-	public async setSuperSourceBoxSettings(
-		newProps: Partial<SuperSource.SuperSourceBox>,
-		box = 0,
-		ssrcId = 0
-	): Promise<void> {
-		const command = new Commands.SuperSourceBoxParametersCommand(ssrcId, box)
-		command.updateProps(newProps)
-		return this.sendCommand(command)
-	}
-
-	public async setSuperSourceProperties(
-		newProps: Partial<SuperSource.SuperSourceProperties>,
-		ssrcId = 0
-	): Promise<void> {
-		if (this.state && this.state.info.apiVersion >= Enums.ProtocolVersion.V8_0) {
-			const command = new Commands.SuperSourcePropertiesV8Command(ssrcId)
-			command.updateProps(newProps)
-			return this.sendCommand(command)
-		} else {
-			const command = new Commands.SuperSourcePropertiesCommand()
-			command.updateProps(newProps)
-			return this.sendCommand(command)
-		}
-	}
-
-	public async setSuperSourceBorder(newProps: Partial<SuperSource.SuperSourceBorder>, ssrcId = 0): Promise<void> {
-		if (this.state && this.state.info.apiVersion >= Enums.ProtocolVersion.V8_0) {
-			const command = new Commands.SuperSourceBorderCommand(ssrcId)
-			command.updateProps(newProps)
-			return this.sendCommand(command)
-		} else {
-			const command = new Commands.SuperSourcePropertiesCommand()
-			command.updateProps(newProps)
-			return this.sendCommand(command)
-		}
-	}
-
-	public async setInputSettings(newProps: Partial<OmitReadonly<InputChannel>>, input = 0): Promise<void> {
-		const command = new Commands.InputPropertiesCommand(input)
-		command.updateProps(newProps)
-		return this.sendCommand(command)
-	}
-
-	public async setUpstreamKeyerChromaSettings(
-		newProps: Partial<USK.UpstreamKeyerChromaSettings>,
-		me = 0,
-		keyer = 0
-	): Promise<void> {
-		const command = new Commands.MixEffectKeyChromaCommand(me, keyer)
-		command.updateProps(newProps)
-		return this.sendCommand(command)
-	}
-
-	public async setUpstreamKeyerAdvancedChromaProperties(
-		newProps: Partial<USK.UpstreamKeyerAdvancedChromaProperties>,
-		me = 0,
-		keyer = 0
-	): Promise<void> {
-		const command = new Commands.MixEffectKeyAdvancedChromaPropertiesCommand(me, keyer)
-		command.updateProps(newProps)
-		return this.sendCommand(command)
-	}
-	public async setUpstreamKeyerAdvancedChromaSample(
-		newProps: Partial<USK.UpstreamKeyerAdvancedChromaSample>,
-		me = 0,
-		keyer = 0
-	): Promise<void> {
-		const command = new Commands.MixEffectKeyAdvancedChromaSampleCommand(me, keyer)
-		command.updateProps(newProps)
-		return this.sendCommand(command)
-	}
-	public async setUpstreamKeyerAdvancedChromaSampleReset(
-		flags: Commands.AdvancedChromaSampleResetProps,
-		me = 0,
-		keyer = 0
-	): Promise<void> {
-		const command = new Commands.MixEffectKeyAdvancedChromaSampleResetCommand(me, keyer, flags)
-		return this.sendCommand(command)
-	}
-
-	public async setUpstreamKeyerCutSource(cutSource: number, me = 0, keyer = 0): Promise<void> {
-		const command = new Commands.MixEffectKeyCutSourceSetCommand(me, keyer, cutSource)
-		return this.sendCommand(command)
-	}
-
-	public async setUpstreamKeyerFillSource(fillSource: number, me = 0, keyer = 0): Promise<void> {
-		const command = new Commands.MixEffectKeyFillSourceSetCommand(me, keyer, fillSource)
-		return this.sendCommand(command)
-	}
-
-	public async setUpstreamKeyerDVESettings(
-		newProps: Partial<USK.UpstreamKeyerDVESettings>,
-		me = 0,
-		keyer = 0
-	): Promise<void> {
-		const command = new Commands.MixEffectKeyDVECommand(me, keyer)
-		command.updateProps(newProps)
-		return this.sendCommand(command)
-	}
-
-	public async setUpstreamKeyerLumaSettings(
-		newProps: Partial<USK.UpstreamKeyerLumaSettings>,
-		me = 0,
-		keyer = 0
-	): Promise<void> {
-		const command = new Commands.MixEffectKeyLumaCommand(me, keyer)
-		command.updateProps(newProps)
-		return this.sendCommand(command)
-	}
-
-	public async setUpstreamKeyerMaskSettings(
-		newProps: Partial<USK.UpstreamKeyerMaskSettings>,
-		me = 0,
-		keyer = 0
-	): Promise<void> {
-		const command = new Commands.MixEffectKeyMaskSetCommand(me, keyer)
-		command.updateProps(newProps)
-		return this.sendCommand(command)
-	}
-
-	public async setUpstreamKeyerPatternSettings(
-		newProps: Partial<USK.UpstreamKeyerPatternSettings>,
-		me = 0,
-		keyer = 0
-	): Promise<void> {
-		const command = new Commands.MixEffectKeyPatternCommand(me, keyer)
-		command.updateProps(newProps)
-		return this.sendCommand(command)
-	}
-
-	public async setUpstreamKeyerOnAir(onAir: boolean, me = 0, keyer = 0): Promise<void> {
-		const command = new Commands.MixEffectKeyOnAirCommand(me, keyer, onAir)
-		return this.sendCommand(command)
-	}
-
-	public async runUpstreamKeyerFlyKeyTo(
-		mixEffect: number,
-		upstreamKeyerId: number,
-		keyFrameId: Enums.FlyKeyKeyFrame.A | Enums.FlyKeyKeyFrame.B | Enums.FlyKeyKeyFrame.Full
-	): Promise<void> {
-		const command = new Commands.MixEffectKeyRunToCommand(mixEffect, upstreamKeyerId, keyFrameId, 0)
-		return this.sendCommand(command)
-	}
-	public async runUpstreamKeyerFlyKeyToInfinite(
-		mixEffect: number,
-		upstreamKeyerId: number,
-		direction: Enums.FlyKeyDirection
-	): Promise<void> {
-		const command = new Commands.MixEffectKeyRunToCommand(
-			mixEffect,
-			upstreamKeyerId,
-			Enums.FlyKeyKeyFrame.RunToInfinite,
-			direction
-		)
-		return this.sendCommand(command)
-	}
-	public async storeUpstreamKeyerFlyKeyKeyframe(
-		mixEffect: number,
-		upstreamKeyerId: number,
-		keyframe: number
-	): Promise<void> {
-		const command = new Commands.MixEffectKeyFlyKeyframeStoreCommand(mixEffect, upstreamKeyerId, keyframe)
-		return this.sendCommand(command)
-	}
-	public async setUpstreamKeyerFlyKeyKeyframe(
-		mixEffect: number,
-		upstreamKeyerId: number,
-		keyframe: number,
-		properties: Partial<Omit<USK.UpstreamKeyerFlyKeyframe, 'keyFrameId'>>
-	): Promise<void> {
-		const command = new Commands.MixEffectKeyFlyKeyframeCommand(mixEffect, upstreamKeyerId, keyframe)
-		command.updateProps(properties)
-		return this.sendCommand(command)
-	}
-
-	public async setUpstreamKeyerType(
-		newProps: Partial<USK.UpstreamKeyerTypeSettings>,
-		me = 0,
-		keyer = 0
-	): Promise<void> {
-		const command = new Commands.MixEffectKeyTypeSetCommand(me, keyer)
-		command.updateProps(newProps)
-		return this.sendCommand(command)
+		return this.#client.dataTransferManager.uploadMacro(index, data, name)
 	}
 
 	/**
@@ -779,7 +412,7 @@ export class Atem extends BasicAtem {
 	 * @returns Promise which returns the image once downloaded. If the still slot is not in use, this will throw
 	 */
 	public async downloadStill(index: number, format: 'raw' | 'rgba' | 'yuv' = 'rgba'): Promise<Buffer> {
-		let rawBuffer = await this.dataTransferManager.downloadStill(index)
+		let rawBuffer = await this.#client.dataTransferManager.downloadStill(index)
 
 		if (format === 'raw') {
 			return rawBuffer
@@ -826,7 +459,7 @@ export class Atem extends BasicAtem {
 
 		const encodedData = generateUploadBufferInfo(data, resolution, !options?.disableRLE)
 
-		return this.dataTransferManager.uploadStill(index, encodedData, name, description)
+		return this.#client.dataTransferManager.uploadStill(index, encodedData, name, description)
 	}
 
 	/**
@@ -856,7 +489,7 @@ export class Atem extends BasicAtem {
 				yield generateUploadBufferInfo(frame, resolution, !options?.disableRLE)
 			}
 		}
-		return this.dataTransferManager.uploadClip(index, provideFrame(), name)
+		return this.#client.dataTransferManager.uploadClip(index, provideFrame(), name)
 	}
 
 	/**
@@ -867,288 +500,7 @@ export class Atem extends BasicAtem {
 	 * @returns Promise which resolves once the clip audio is uploaded
 	 */
 	public async uploadAudio(index: number, data: Buffer, name: string): Promise<void> {
-		return this.dataTransferManager.uploadAudio(index, convertWAVToRaw(data, this.state?.info?.model), name)
-	}
-
-	public async setClassicAudioMixerInputProps(
-		index: number,
-		props: Partial<OmitReadonly<ClassicAudioChannel>>
-	): Promise<void> {
-		const command = new Commands.AudioMixerInputCommand(index)
-		command.updateProps(props)
-		return this.sendCommand(command)
-	}
-
-	public async setClassicAudioMixerMasterProps(props: Partial<ClassicAudioMasterChannel>): Promise<void> {
-		const command = new Commands.AudioMixerMasterCommand()
-		command.updateProps(props)
-		return this.sendCommand(command)
-	}
-
-	public async setClassicAudioMixerMonitorProps(props: Partial<ClassicAudioMonitorChannel>): Promise<void> {
-		const command = new Commands.AudioMixerMonitorCommand()
-		command.updateProps(props)
-		return this.sendCommand(command)
-	}
-
-	public async setClassicAudioMixerHeadphonesProps(
-		props: Partial<ClassicAudioHeadphoneOutputChannel>
-	): Promise<void> {
-		const command = new Commands.AudioMixerHeadphonesCommand()
-		command.updateProps(props)
-		return this.sendCommand(command)
-	}
-
-	public async setClassicAudioResetPeaks(props: Partial<Commands.ClassicAudioResetPeaks>): Promise<void> {
-		const command = new Commands.AudioMixerResetPeaksCommand()
-		command.updateProps(props)
-		return this.sendCommand(command)
-	}
-
-	public async setClassicAudioMixerProps(props: Commands.AudioMixerPropertiesCommand['properties']): Promise<void> {
-		const command = new Commands.AudioMixerPropertiesCommand(props)
-		return this.sendCommand(command)
-	}
-
-	public async setFairlightAudioMixerMasterProps(
-		props: Partial<Commands.FairlightMixerMasterCommandProperties>
-	): Promise<void> {
-		const command = new Commands.FairlightMixerMasterCommand()
-		command.updateProps(props)
-		return this.sendCommand(command)
-	}
-
-	public async setFairlightAudioMixerMasterCompressorProps(
-		props: Partial<OmitReadonly<FairlightAudioCompressorState>>
-	): Promise<void> {
-		const command = new Commands.FairlightMixerMasterCompressorCommand()
-		command.updateProps(props)
-		return this.sendCommand(command)
-	}
-
-	public async setFairlightAudioMixerMasterLimiterProps(
-		props: Partial<OmitReadonly<FairlightAudioLimiterState>>
-	): Promise<void> {
-		const command = new Commands.FairlightMixerMasterLimiterCommand()
-		command.updateProps(props)
-		return this.sendCommand(command)
-	}
-
-	public async setFairlightAudioMixerMasterEqualizerBandProps(
-		band: number,
-		props: Partial<OmitReadonly<FairlightAudioEqualizerBandState>>
-	): Promise<void> {
-		const command = new Commands.FairlightMixerMasterEqualizerBandCommand(band)
-		command.updateProps(props)
-		return this.sendCommand(command)
-	}
-
-	public async setFairlightAudioMixerMasterEqualizerReset(
-		props: Partial<Commands.FairlightMixerMasterEqualizerResetCommand['properties']>
-	): Promise<void> {
-		const command = new Commands.FairlightMixerMasterEqualizerResetCommand()
-		command.updateProps(props)
-		return this.sendCommand(command)
-	}
-
-	public async setFairlightAudioMixerMasterDynamicsReset(props: Partial<FairlightDynamicsResetProps>): Promise<void> {
-		const command = new Commands.FairlightMixerMasterDynamicsResetCommand()
-		command.updateProps(props)
-		return this.sendCommand(command)
-	}
-
-	public async setFairlightAudioMixerResetPeaks(
-		props: Commands.FairlightMixerResetPeakLevelsCommand['properties']
-	): Promise<void> {
-		const command = new Commands.FairlightMixerResetPeakLevelsCommand(props)
-		return this.sendCommand(command)
-	}
-
-	public async startFairlightMixerSendLevels(): Promise<void> {
-		const command = new Commands.FairlightMixerSendLevelsCommand(true)
-		return this.sendCommand(command)
-	}
-
-	public async stopFairlightMixerSendLevels(): Promise<void> {
-		const command = new Commands.FairlightMixerSendLevelsCommand(false)
-		return this.sendCommand(command)
-	}
-
-	public async setFairlightAudioMixerMonitorProps(
-		props: Partial<OmitReadonly<FairlightAudioMonitorChannel>>
-	): Promise<void> {
-		const command = new Commands.FairlightMixerMonitorCommand()
-		command.updateProps(props)
-		return this.sendCommand(command)
-	}
-
-	public async setFairlightAudioMixerMonitorSolo(
-		props: Partial<OmitReadonly<FairlightAudioMonitorSolo>>
-	): Promise<void> {
-		const command = new Commands.FairlightMixerMonitorSoloCommand()
-		command.updateProps(props)
-		return this.sendCommand(command)
-	}
-
-	public async setFairlightAudioMixerInputProps(
-		index: number,
-		props: Commands.FairlightMixerInputCommand['properties']
-	): Promise<void> {
-		if (this.state && this.state.info.apiVersion >= Enums.ProtocolVersion.V8_0) {
-			const command = new Commands.FairlightMixerInputV8Command(index)
-			command.updateProps(props)
-			return this.sendCommand(command)
-		} else {
-			const command = new Commands.FairlightMixerInputCommand(index)
-			command.updateProps(props)
-			return this.sendCommand(command)
-		}
-	}
-
-	public async setFairlightAudioMixerSourceProps(
-		index: number,
-		source: string,
-		props: Commands.FairlightMixerSourceCommand['properties']
-	): Promise<void> {
-		const command = new Commands.FairlightMixerSourceCommand(index, BigInt(source))
-		command.updateProps(props)
-		return this.sendCommand(command)
-	}
-
-	public async setFairlightAudioMixerSourceCompressorProps(
-		index: number,
-		source: string,
-		props: Partial<OmitReadonly<FairlightAudioCompressorState>>
-	): Promise<void> {
-		const command = new Commands.FairlightMixerSourceCompressorCommand(index, BigInt(source))
-		command.updateProps(props)
-		return this.sendCommand(command)
-	}
-
-	public async setFairlightAudioMixerSourceLimiterProps(
-		index: number,
-		source: string,
-		props: Partial<OmitReadonly<FairlightAudioLimiterState>>
-	): Promise<void> {
-		const command = new Commands.FairlightMixerSourceLimiterCommand(index, BigInt(source))
-		command.updateProps(props)
-		return this.sendCommand(command)
-	}
-
-	public async setFairlightAudioMixerSourceExpanderProps(
-		index: number,
-		source: string,
-		props: Partial<OmitReadonly<FairlightAudioExpanderState>>
-	): Promise<void> {
-		const command = new Commands.FairlightMixerSourceExpanderCommand(index, BigInt(source))
-		command.updateProps(props)
-		return this.sendCommand(command)
-	}
-
-	public async setFairlightAudioMixerSourceEqualizerBandProps(
-		index: number,
-		source: string,
-		band: number,
-		props: Partial<OmitReadonly<FairlightAudioEqualizerBandState>>
-	): Promise<void> {
-		const command = new Commands.FairlightMixerSourceEqualizerBandCommand(index, BigInt(source), band)
-		command.updateProps(props)
-		return this.sendCommand(command)
-	}
-
-	public async setFairlightAudioMixerSourceDynamicsReset(
-		index: number,
-		source: string,
-		props: Partial<FairlightDynamicsResetProps>
-	): Promise<void> {
-		const command = new Commands.FairlightMixerSourceDynamicsResetCommand(index, BigInt(source))
-		command.updateProps(props)
-		return this.sendCommand(command)
-	}
-
-	public async setFairlightAudioMixerSourceEqualizerReset(
-		index: number,
-		source: string,
-		props: Partial<Commands.FairlightMixerSourceEqualizerResetCommand['properties']>
-	): Promise<void> {
-		const command = new Commands.FairlightMixerSourceEqualizerResetCommand(index, BigInt(source))
-		command.updateProps(props)
-		return this.sendCommand(command)
-	}
-
-	public async setFairlightAudioMixerSourceResetPeaks(
-		index: number,
-		source: string,
-		props: Commands.FairlightMixerSourceResetPeakLevelsCommand['properties']
-	): Promise<void> {
-		const command = new Commands.FairlightMixerSourceResetPeakLevelsCommand(index, BigInt(source), props)
-		return this.sendCommand(command)
-	}
-
-	public async startStreaming(): Promise<void> {
-		const command = new Commands.StreamingStatusCommand(true)
-		return this.sendCommand(command)
-	}
-
-	public async stopStreaming(): Promise<void> {
-		const command = new Commands.StreamingStatusCommand(false)
-		return this.sendCommand(command)
-	}
-
-	public async requestStreamingDuration(): Promise<void> {
-		const command = new Commands.StreamingRequestDurationCommand()
-		return this.sendCommand(command)
-	}
-
-	public async setStreamingService(props: Partial<StreamingServiceProperties>): Promise<void> {
-		const command = new Commands.StreamingServiceCommand()
-		command.updateProps(props)
-		return this.sendCommand(command)
-	}
-
-	public async setStreamingAudioBitrates(lowBitrate: number, highBitrate: number): Promise<void> {
-		const command = new Commands.StreamingAudioBitratesCommand(lowBitrate, highBitrate)
-		return this.sendCommand(command)
-	}
-
-	public async startRecording(): Promise<void> {
-		const command = new Commands.RecordingStatusCommand(true)
-		return this.sendCommand(command)
-	}
-
-	public async stopRecording(): Promise<void> {
-		const command = new Commands.RecordingStatusCommand(false)
-		return this.sendCommand(command)
-	}
-
-	public async requestRecordingDuration(): Promise<void> {
-		const command = new Commands.RecordingRequestDurationCommand()
-		return this.sendCommand(command)
-	}
-
-	public async switchRecordingDisk(): Promise<void> {
-		const command = new Commands.RecordingRequestSwitchDiskCommand()
-		return this.sendCommand(command)
-	}
-
-	public async setRecordingSettings(props: Partial<RecordingStateProperties>): Promise<void> {
-		const command = new Commands.RecordingSettingsCommand()
-		command.updateProps(props)
-		return this.sendCommand(command)
-	}
-
-	public async setEnableISORecording(enabled: boolean): Promise<void> {
-		const command = new Commands.RecordingISOCommand(enabled)
-		return this.sendCommand(command)
-	}
-
-	public async saveStartupState(): Promise<void> {
-		const command = new Commands.StartupStateSaveCommand()
-		return this.sendCommand(command)
-	}
-	public async clearStartupState(): Promise<void> {
-		const command = new Commands.StartupStateClearCommand()
-		return this.sendCommand(command)
+		return this.#client.dataTransferManager.uploadAudio(index, convertWAVToRaw(data, this.state?.info?.model), name)
 	}
 
 	public listVisibleInputs(mode: 'program' | 'preview', me = 0): number[] {
@@ -1157,45 +509,6 @@ export class Atem extends BasicAtem {
 		} else {
 			return []
 		}
-	}
-
-	public async setMediaPoolSettings(props: Commands.MediaPoolProps): Promise<void> {
-		const command = new Commands.MediaPoolSettingsSetCommand(props.maxFrames)
-		return this.sendCommand(command)
-	}
-
-	public async requestDisplayClockTime(): Promise<void> {
-		const command = new Commands.DisplayClockRequestTimeCommand()
-		return this.sendCommand(command)
-	}
-
-	public async setDisplayClockState(state: Enums.DisplayClockClockState): Promise<void> {
-		const command = new Commands.DisplayClockStateSetCommand(state)
-		return this.sendCommand(command)
-	}
-
-	public async setDisplayClockProperties(props: Partial<Commands.DisplayClockPropertiesExt>): Promise<void> {
-		const command = new Commands.DisplayClockPropertiesSetCommand()
-		command.updateProps(props)
-		return this.sendCommand(command)
-	}
-
-	public async setFairlightAudioRoutingSourceProperties(
-		sourceId: number,
-		props: Partial<OmitReadonly<FairlightAudioRoutingSource>>
-	): Promise<void> {
-		const command = new Commands.AudioRoutingSourceCommand(sourceId)
-		command.updateProps(props)
-		return this.sendCommand(command)
-	}
-
-	public async setFairlightAudioRoutingOutputProperties(
-		sourceId: number,
-		props: Partial<OmitReadonly<FairlightAudioRoutingOutput>>
-	): Promise<void> {
-		const command = new Commands.AudioRoutingOutputCommand(sourceId)
-		command.updateProps(props)
-		return this.sendCommand(command)
 	}
 
 	public hasInternalMultiviewerLabelGeneration(): boolean {
@@ -1219,7 +532,7 @@ export class Atem extends BasicAtem {
 			}
 		}
 
-		return this.dataTransferManager.uploadMultiViewerLabel(inputId, buffer)
+		return this.#client.dataTransferManager.uploadMultiViewerLabel(inputId, buffer)
 	}
 
 	/**
@@ -1238,6 +551,112 @@ export class Atem extends BasicAtem {
 
 		const buffer = generateMultiviewerLabel(fontFace, this.#multiviewerFontScale, text, props)
 		// Note: we should probably validate the buffer looks like it doesn't contain crashy data, but as we generate we can trust it
-		return this.dataTransferManager.uploadMultiViewerLabel(inputId, buffer)
+		return this.#client.dataTransferManager.uploadMultiViewerLabel(inputId, buffer)
 	}
+
+	/** @begin EventEmitter */
+	/* This isn't nice, but is necessary to 'extend' two classes */
+
+	/**
+	 * Return an array listing the events for which the emitter has registered
+	 * listeners.
+	 */
+	eventNames(): Array<EventEmitter.EventNames<AtemEvents>> {
+		return this.#events.eventNames()
+	}
+
+	/**
+	 * Return the listeners registered for a given event.
+	 */
+	listeners<T extends EventEmitter.EventNames<AtemEvents>>(
+		event: T
+	): Array<EventEmitter.EventListener<AtemEvents, T>> {
+		return this.#events.listeners(event)
+	}
+
+	/**
+	 * Return the number of listeners listening to a given event.
+	 */
+	listenerCount(event: EventEmitter.EventNames<AtemEvents>): number {
+		return this.#events.listenerCount(event)
+	}
+
+	/**
+	 * Calls each of the listeners registered for a given event.
+	 */
+	emit<T extends EventEmitter.EventNames<AtemEvents>>(
+		event: T,
+		...args: EventEmitter.EventArgs<AtemEvents, T>
+	): boolean {
+		return this.#events.emit(event, ...args)
+	}
+
+	/**
+	 * Add a listener for a given event.
+	 */
+	on<T extends EventEmitter.EventNames<AtemEvents>>(
+		event: T,
+		fn: EventEmitter.EventListener<AtemEvents, T>,
+		// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+		context?: any
+	): this {
+		this.#events.on(event, fn, context)
+		return this
+	}
+	addListener<T extends EventEmitter.EventNames<AtemEvents>>(
+		event: T,
+		fn: EventEmitter.EventListener<AtemEvents, T>,
+		// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+		context?: any
+	): this {
+		this.#events.on(event, fn, context)
+		return this
+	}
+
+	/**
+	 * Add a one-time listener for a given event.
+	 */
+	once<T extends EventEmitter.EventNames<AtemEvents>>(
+		event: T,
+		fn: EventEmitter.EventListener<AtemEvents, T>,
+		// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+		context?: any
+	): this {
+		this.#events.once(event, fn, context)
+		return this
+	}
+
+	/**
+	 * Remove the listeners of a given event.
+	 */
+	removeListener<T extends EventEmitter.EventNames<AtemEvents>>(
+		event: T,
+		fn?: EventEmitter.EventListener<AtemEvents, T>,
+		// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+		context?: any,
+		once?: boolean
+	): this {
+		this.#events.removeListener(event, fn, context, once)
+		return this
+	}
+	off<T extends EventEmitter.EventNames<AtemEvents>>(
+		event: T,
+		fn?: EventEmitter.EventListener<AtemEvents, T>,
+		// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+		context?: any,
+		once?: boolean
+	): this {
+		this.#events.off(event, fn, context, once)
+		return this
+	}
+
+	/**
+	 * Remove all listeners, or those of the specified event.
+	 */
+	removeAllListeners(event?: EventEmitter.EventNames<AtemEvents>): this {
+		this.#events.removeAllListeners(event)
+		return this
+	}
+
+	/** @end EventEmitter */
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ import * as Commands from './commands'
 import * as Util from './lib/atemUtil'
 export { Enums, Commands, Util }
 export { listVisibleInputs } from './lib/tally'
+export * from './lib/atemCommands'
+export * from './lib/batchCommands'
 
 import * as VideoState from './state/video'
 import * as AudioState from './state/audio'

--- a/src/lib/atemCommands.ts
+++ b/src/lib/atemCommands.ts
@@ -1,0 +1,752 @@
+import type {
+	ClassicAudioChannel,
+	ClassicAudioMasterChannel,
+	ClassicAudioMonitorChannel,
+	ClassicAudioHeadphoneOutputChannel,
+} from '../state/audio'
+import type {
+	FairlightAudioCompressorState,
+	FairlightAudioLimiterState,
+	FairlightAudioEqualizerBandState,
+	FairlightAudioMonitorChannel,
+	FairlightAudioMonitorSolo,
+	FairlightAudioExpanderState,
+	FairlightAudioRoutingSource,
+	FairlightAudioRoutingOutput,
+} from '../state/fairlight'
+import type { InputChannel } from '../state/input'
+import type { MediaPlayer, MediaPlayerSource } from '../state/media'
+import type { RecordingStateProperties } from '../state/recording'
+import type { MultiViewerPropertiesState } from '../state/settings'
+import type { StreamingServiceProperties } from '../state/streaming'
+import type { ColorGeneratorState } from '../state/color'
+import type {
+	DipTransitionSettings,
+	DVETransitionSettings,
+	MixTransitionSettings,
+	TransitionProperties,
+	StingerTransitionSettings,
+	WipeTransitionSettings,
+	SuperSource,
+	USK,
+} from '../state/video'
+import type { DownstreamKeyerGeneral, DownstreamKeyerMask } from '../state/video/downstreamKeyers'
+import type { ISerializableCommand } from '../commands'
+import * as Enums from '../enums'
+import * as Commands from '../commands'
+import type { OmitReadonly } from './types'
+import type { FairlightDynamicsResetProps } from '../commands/Fairlight/common'
+
+/**
+ * Base class for sending commands to the ATEM switcher.
+ * Any sending of comamnds should be done through this class, allowing it to be used in both a direct or batched manner.
+ */
+export abstract class AtemCommandSender<T> {
+	protected abstract sendCommand(command: ISerializableCommand): T
+
+	protected abstract readonly apiVersion: Enums.ProtocolVersion | undefined
+
+	public changeProgramInput(input: number, me = 0): T {
+		const command = new Commands.ProgramInputCommand(me, input)
+		return this.sendCommand(command)
+	}
+
+	public changePreviewInput(input: number, me = 0): T {
+		const command = new Commands.PreviewInputCommand(me, input)
+		return this.sendCommand(command)
+	}
+
+	public cut(me = 0): T {
+		const command = new Commands.CutCommand(me)
+		return this.sendCommand(command)
+	}
+
+	public autoTransition(me = 0): T {
+		const command = new Commands.AutoTransitionCommand(me)
+		return this.sendCommand(command)
+	}
+
+	public fadeToBlack(me = 0): T {
+		const command = new Commands.FadeToBlackAutoCommand(me)
+		return this.sendCommand(command)
+	}
+
+	public setFadeToBlackRate(rate: number, me = 0): T {
+		const command = new Commands.FadeToBlackRateCommand(me, rate)
+		return this.sendCommand(command)
+	}
+
+	public autoDownstreamKey(key = 0, isTowardsOnAir?: boolean): T {
+		const command = new Commands.DownstreamKeyAutoCommand(key)
+		command.updateProps({ isTowardsOnAir })
+		return this.sendCommand(command)
+	}
+
+	public setDipTransitionSettings(newProps: Partial<DipTransitionSettings>, me = 0): T {
+		const command = new Commands.TransitionDipCommand(me)
+		command.updateProps(newProps)
+		return this.sendCommand(command)
+	}
+
+	public setDVETransitionSettings(newProps: Partial<DVETransitionSettings>, me = 0): T {
+		const command = new Commands.TransitionDVECommand(me)
+		command.updateProps(newProps)
+		return this.sendCommand(command)
+	}
+
+	public setMixTransitionSettings(newProps: Pick<MixTransitionSettings, 'rate'>, me = 0): T {
+		const command = new Commands.TransitionMixCommand(me, newProps.rate)
+		return this.sendCommand(command)
+	}
+
+	public setTransitionPosition(position: number, me = 0): T {
+		const command = new Commands.TransitionPositionCommand(me, position)
+		return this.sendCommand(command)
+	}
+
+	public previewTransition(on: boolean, me = 0): T {
+		const command = new Commands.PreviewTransitionCommand(me, on)
+		return this.sendCommand(command)
+	}
+
+	public setTransitionStyle(newProps: Partial<OmitReadonly<TransitionProperties>>, me = 0): T {
+		const command = new Commands.TransitionPropertiesCommand(me)
+		command.updateProps(newProps)
+		return this.sendCommand(command)
+	}
+
+	public setStingerTransitionSettings(newProps: Partial<StingerTransitionSettings>, me = 0): T {
+		const command = new Commands.TransitionStingerCommand(me)
+		command.updateProps(newProps)
+		return this.sendCommand(command)
+	}
+
+	public setWipeTransitionSettings(newProps: Partial<WipeTransitionSettings>, me = 0): T {
+		const command = new Commands.TransitionWipeCommand(me)
+		command.updateProps(newProps)
+		return this.sendCommand(command)
+	}
+
+	public setAuxSource(source: number, bus = 0): T {
+		const command = new Commands.AuxSourceCommand(bus, source)
+		return this.sendCommand(command)
+	}
+
+	public setDownstreamKeyTie(tie: boolean, key = 0): T {
+		const command = new Commands.DownstreamKeyTieCommand(key, tie)
+		return this.sendCommand(command)
+	}
+
+	public setDownstreamKeyOnAir(onAir: boolean, key = 0): T {
+		const command = new Commands.DownstreamKeyOnAirCommand(key, onAir)
+		return this.sendCommand(command)
+	}
+
+	public setDownstreamKeyCutSource(input: number, key = 0): T {
+		const command = new Commands.DownstreamKeyCutSourceCommand(key, input)
+		return this.sendCommand(command)
+	}
+
+	public setDownstreamKeyFillSource(input: number, key = 0): T {
+		const command = new Commands.DownstreamKeyFillSourceCommand(key, input)
+		return this.sendCommand(command)
+	}
+
+	public setDownstreamKeyGeneralProperties(props: Partial<DownstreamKeyerGeneral>, key = 0): T {
+		const command = new Commands.DownstreamKeyGeneralCommand(key)
+		command.updateProps(props)
+		return this.sendCommand(command)
+	}
+
+	public setDownstreamKeyMaskSettings(props: Partial<DownstreamKeyerMask>, key = 0): T {
+		const command = new Commands.DownstreamKeyMaskCommand(key)
+		command.updateProps(props)
+		return this.sendCommand(command)
+	}
+
+	public setDownstreamKeyRate(rate: number, key = 0): T {
+		const command = new Commands.DownstreamKeyRateCommand(key, rate)
+		return this.sendCommand(command)
+	}
+
+	public setTime(hour: number, minute: number, second: number, frame: number): T {
+		const command = new Commands.TimeCommand({ hour, minute, second, frame })
+		return this.sendCommand(command)
+	}
+
+	public setTimeMode(mode: Enums.TimeMode): T {
+		const command = new Commands.TimeConfigCommand(mode)
+		return this.sendCommand(command)
+	}
+
+	public requestTime(): T {
+		const command = new Commands.TimeRequestCommand()
+		return this.sendCommand(command)
+	}
+
+	public macroContinue(): T {
+		const command = new Commands.MacroActionCommand(0, Enums.MacroAction.Continue)
+		return this.sendCommand(command)
+	}
+
+	public macroDelete(index = 0): T {
+		const command = new Commands.MacroActionCommand(index, Enums.MacroAction.Delete)
+		return this.sendCommand(command)
+	}
+
+	public macroInsertUserWait(): T {
+		const command = new Commands.MacroActionCommand(0, Enums.MacroAction.InsertUserWait)
+		return this.sendCommand(command)
+	}
+
+	public macroInsertTimedWait(frames: number): T {
+		const command = new Commands.MacroAddTimedPauseCommand(frames)
+		return this.sendCommand(command)
+	}
+
+	public macroRun(index = 0): T {
+		const command = new Commands.MacroActionCommand(index, Enums.MacroAction.Run)
+		return this.sendCommand(command)
+	}
+
+	public macroStop(): T {
+		const command = new Commands.MacroActionCommand(0, Enums.MacroAction.Stop)
+		return this.sendCommand(command)
+	}
+
+	public macroStartRecord(index: number, name: string, description: string): T {
+		const command = new Commands.MacroRecordCommand(index, name, description)
+		return this.sendCommand(command)
+	}
+
+	public macroStopRecord(): T {
+		const command = new Commands.MacroActionCommand(0, Enums.MacroAction.StopRecord)
+		return this.sendCommand(command)
+	}
+
+	public macroUpdateProperties(props: Commands.MacroPropertiesCommand['properties'], index = 0): T {
+		const command = new Commands.MacroPropertiesCommand(index)
+		command.updateProps(props)
+		return this.sendCommand(command)
+	}
+
+	public macroSetLoop(loop: boolean): T {
+		const command = new Commands.MacroRunStatusCommand()
+		command.updateProps({ loop })
+		return this.sendCommand(command)
+	}
+
+	public setMultiViewerWindowSource(source: number, mv = 0, window = 0): T {
+		const command = new Commands.MultiViewerSourceCommand(mv, window, source)
+		return this.sendCommand(command)
+	}
+	public setMultiViewerWindowSafeAreaEnabled(safeAreaEnabled: boolean, mv = 0, window = 0): T {
+		const command = new Commands.MultiViewerWindowSafeAreaCommand(mv, window, safeAreaEnabled)
+		return this.sendCommand(command)
+	}
+	public setMultiViewerWindowVuEnabled(vuEnabled: boolean, mv = 0, window = 0): T {
+		const command = new Commands.MultiViewerWindowVuMeterCommand(mv, window, vuEnabled)
+		return this.sendCommand(command)
+	}
+
+	public setMultiViewerVuOpacity(opacity: number, mv = 0): T {
+		const command = new Commands.MultiViewerVuOpacityCommand(mv, opacity)
+		return this.sendCommand(command)
+	}
+	public setMultiViewerProperties(props: Partial<MultiViewerPropertiesState>, mv = 0): T {
+		const command = new Commands.MultiViewerPropertiesCommand(mv)
+		command.updateProps(props)
+		return this.sendCommand(command)
+	}
+
+	public setColorGeneratorColour(newProps: Partial<ColorGeneratorState>, index = 0): T {
+		const command = new Commands.ColorGeneratorCommand(index)
+		command.updateProps(newProps)
+		return this.sendCommand(command)
+	}
+
+	public setMediaPlayerSettings(newProps: Partial<MediaPlayer>, player = 0): T {
+		const command = new Commands.MediaPlayerStatusCommand(player)
+		command.updateProps(newProps)
+		return this.sendCommand(command)
+	}
+
+	public setMediaPlayerSource(newProps: Partial<MediaPlayerSource>, player = 0): T {
+		const command = new Commands.MediaPlayerSourceCommand(player)
+		command.updateProps(newProps)
+		return this.sendCommand(command)
+	}
+
+	public setMediaClip(index: number, name: string, frames = 1): T {
+		const command = new Commands.MediaPoolSetClipCommand({ index, name, frames })
+		return this.sendCommand(command)
+	}
+
+	public clearMediaPoolClip(clipId: number): T {
+		const command = new Commands.MediaPoolClearClipCommand(clipId)
+		return this.sendCommand(command)
+	}
+
+	public clearMediaPoolStill(stillId: number): T {
+		const command = new Commands.MediaPoolClearStillCommand(stillId)
+		return this.sendCommand(command)
+	}
+
+	public captureMediaPoolStill(): T {
+		const command = new Commands.MediaPoolCaptureStillCommand()
+		return this.sendCommand(command)
+	}
+
+	public setSuperSourceBoxSettings(newProps: Partial<SuperSource.SuperSourceBox>, box = 0, ssrcId = 0): T {
+		const command = new Commands.SuperSourceBoxParametersCommand(ssrcId, box)
+		command.updateProps(newProps)
+		return this.sendCommand(command)
+	}
+
+	public setSuperSourceProperties(newProps: Partial<SuperSource.SuperSourceProperties>, ssrcId = 0): T {
+		if (this.apiVersion && this.apiVersion >= Enums.ProtocolVersion.V8_0) {
+			const command = new Commands.SuperSourcePropertiesV8Command(ssrcId)
+			command.updateProps(newProps)
+			return this.sendCommand(command)
+		} else {
+			const command = new Commands.SuperSourcePropertiesCommand()
+			command.updateProps(newProps)
+			return this.sendCommand(command)
+		}
+	}
+
+	public setSuperSourceBorder(newProps: Partial<SuperSource.SuperSourceBorder>, ssrcId = 0): T {
+		if (this.apiVersion && this.apiVersion >= Enums.ProtocolVersion.V8_0) {
+			const command = new Commands.SuperSourceBorderCommand(ssrcId)
+			command.updateProps(newProps)
+			return this.sendCommand(command)
+		} else {
+			const command = new Commands.SuperSourcePropertiesCommand()
+			command.updateProps(newProps)
+			return this.sendCommand(command)
+		}
+	}
+
+	public setInputSettings(newProps: Partial<OmitReadonly<InputChannel>>, input = 0): T {
+		const command = new Commands.InputPropertiesCommand(input)
+		command.updateProps(newProps)
+		return this.sendCommand(command)
+	}
+
+	public setUpstreamKeyerChromaSettings(newProps: Partial<USK.UpstreamKeyerChromaSettings>, me = 0, keyer = 0): T {
+		const command = new Commands.MixEffectKeyChromaCommand(me, keyer)
+		command.updateProps(newProps)
+		return this.sendCommand(command)
+	}
+
+	public setUpstreamKeyerAdvancedChromaProperties(
+		newProps: Partial<USK.UpstreamKeyerAdvancedChromaProperties>,
+		me = 0,
+		keyer = 0
+	): T {
+		const command = new Commands.MixEffectKeyAdvancedChromaPropertiesCommand(me, keyer)
+		command.updateProps(newProps)
+		return this.sendCommand(command)
+	}
+	public setUpstreamKeyerAdvancedChromaSample(
+		newProps: Partial<USK.UpstreamKeyerAdvancedChromaSample>,
+		me = 0,
+		keyer = 0
+	): T {
+		const command = new Commands.MixEffectKeyAdvancedChromaSampleCommand(me, keyer)
+		command.updateProps(newProps)
+		return this.sendCommand(command)
+	}
+	public setUpstreamKeyerAdvancedChromaSampleReset(
+		flags: Commands.AdvancedChromaSampleResetProps,
+		me = 0,
+		keyer = 0
+	): T {
+		const command = new Commands.MixEffectKeyAdvancedChromaSampleResetCommand(me, keyer, flags)
+		return this.sendCommand(command)
+	}
+
+	public setUpstreamKeyerCutSource(cutSource: number, me = 0, keyer = 0): T {
+		const command = new Commands.MixEffectKeyCutSourceSetCommand(me, keyer, cutSource)
+		return this.sendCommand(command)
+	}
+
+	public setUpstreamKeyerFillSource(fillSource: number, me = 0, keyer = 0): T {
+		const command = new Commands.MixEffectKeyFillSourceSetCommand(me, keyer, fillSource)
+		return this.sendCommand(command)
+	}
+
+	public setUpstreamKeyerDVESettings(newProps: Partial<USK.UpstreamKeyerDVESettings>, me = 0, keyer = 0): T {
+		const command = new Commands.MixEffectKeyDVECommand(me, keyer)
+		command.updateProps(newProps)
+		return this.sendCommand(command)
+	}
+
+	public setUpstreamKeyerLumaSettings(newProps: Partial<USK.UpstreamKeyerLumaSettings>, me = 0, keyer = 0): T {
+		const command = new Commands.MixEffectKeyLumaCommand(me, keyer)
+		command.updateProps(newProps)
+		return this.sendCommand(command)
+	}
+
+	public setUpstreamKeyerMaskSettings(newProps: Partial<USK.UpstreamKeyerMaskSettings>, me = 0, keyer = 0): T {
+		const command = new Commands.MixEffectKeyMaskSetCommand(me, keyer)
+		command.updateProps(newProps)
+		return this.sendCommand(command)
+	}
+
+	public setUpstreamKeyerPatternSettings(newProps: Partial<USK.UpstreamKeyerPatternSettings>, me = 0, keyer = 0): T {
+		const command = new Commands.MixEffectKeyPatternCommand(me, keyer)
+		command.updateProps(newProps)
+		return this.sendCommand(command)
+	}
+
+	public setUpstreamKeyerOnAir(onAir: boolean, me = 0, keyer = 0): T {
+		const command = new Commands.MixEffectKeyOnAirCommand(me, keyer, onAir)
+		return this.sendCommand(command)
+	}
+
+	public runUpstreamKeyerFlyKeyTo(
+		mixEffect: number,
+		upstreamKeyerId: number,
+		keyFrameId: Enums.FlyKeyKeyFrame.A | Enums.FlyKeyKeyFrame.B | Enums.FlyKeyKeyFrame.Full
+	): T {
+		const command = new Commands.MixEffectKeyRunToCommand(mixEffect, upstreamKeyerId, keyFrameId, 0)
+		return this.sendCommand(command)
+	}
+	public runUpstreamKeyerFlyKeyToInfinite(
+		mixEffect: number,
+		upstreamKeyerId: number,
+		direction: Enums.FlyKeyDirection
+	): T {
+		const command = new Commands.MixEffectKeyRunToCommand(
+			mixEffect,
+			upstreamKeyerId,
+			Enums.FlyKeyKeyFrame.RunToInfinite,
+			direction
+		)
+		return this.sendCommand(command)
+	}
+	public storeUpstreamKeyerFlyKeyKeyframe(mixEffect: number, upstreamKeyerId: number, keyframe: number): T {
+		const command = new Commands.MixEffectKeyFlyKeyframeStoreCommand(mixEffect, upstreamKeyerId, keyframe)
+		return this.sendCommand(command)
+	}
+	public setUpstreamKeyerFlyKeyKeyframe(
+		mixEffect: number,
+		upstreamKeyerId: number,
+		keyframe: number,
+		properties: Partial<Omit<USK.UpstreamKeyerFlyKeyframe, 'keyFrameId'>>
+	): T {
+		const command = new Commands.MixEffectKeyFlyKeyframeCommand(mixEffect, upstreamKeyerId, keyframe)
+		command.updateProps(properties)
+		return this.sendCommand(command)
+	}
+
+	public setUpstreamKeyerType(newProps: Partial<USK.UpstreamKeyerTypeSettings>, me = 0, keyer = 0): T {
+		const command = new Commands.MixEffectKeyTypeSetCommand(me, keyer)
+		command.updateProps(newProps)
+		return this.sendCommand(command)
+	}
+
+	public setClassicAudioMixerInputProps(index: number, props: Partial<OmitReadonly<ClassicAudioChannel>>): T {
+		const command = new Commands.AudioMixerInputCommand(index)
+		command.updateProps(props)
+		return this.sendCommand(command)
+	}
+
+	public setClassicAudioMixerMasterProps(props: Partial<ClassicAudioMasterChannel>): T {
+		const command = new Commands.AudioMixerMasterCommand()
+		command.updateProps(props)
+		return this.sendCommand(command)
+	}
+
+	public setClassicAudioMixerMonitorProps(props: Partial<ClassicAudioMonitorChannel>): T {
+		const command = new Commands.AudioMixerMonitorCommand()
+		command.updateProps(props)
+		return this.sendCommand(command)
+	}
+
+	public setClassicAudioMixerHeadphonesProps(props: Partial<ClassicAudioHeadphoneOutputChannel>): T {
+		const command = new Commands.AudioMixerHeadphonesCommand()
+		command.updateProps(props)
+		return this.sendCommand(command)
+	}
+
+	public setClassicAudioResetPeaks(props: Partial<Commands.ClassicAudioResetPeaks>): T {
+		const command = new Commands.AudioMixerResetPeaksCommand()
+		command.updateProps(props)
+		return this.sendCommand(command)
+	}
+
+	public setClassicAudioMixerProps(props: Commands.AudioMixerPropertiesCommand['properties']): T {
+		const command = new Commands.AudioMixerPropertiesCommand(props)
+		return this.sendCommand(command)
+	}
+
+	public setFairlightAudioMixerMasterProps(props: Partial<Commands.FairlightMixerMasterCommandProperties>): T {
+		const command = new Commands.FairlightMixerMasterCommand()
+		command.updateProps(props)
+		return this.sendCommand(command)
+	}
+
+	public setFairlightAudioMixerMasterCompressorProps(props: Partial<OmitReadonly<FairlightAudioCompressorState>>): T {
+		const command = new Commands.FairlightMixerMasterCompressorCommand()
+		command.updateProps(props)
+		return this.sendCommand(command)
+	}
+
+	public setFairlightAudioMixerMasterLimiterProps(props: Partial<OmitReadonly<FairlightAudioLimiterState>>): T {
+		const command = new Commands.FairlightMixerMasterLimiterCommand()
+		command.updateProps(props)
+		return this.sendCommand(command)
+	}
+
+	public setFairlightAudioMixerMasterEqualizerBandProps(
+		band: number,
+		props: Partial<OmitReadonly<FairlightAudioEqualizerBandState>>
+	): T {
+		const command = new Commands.FairlightMixerMasterEqualizerBandCommand(band)
+		command.updateProps(props)
+		return this.sendCommand(command)
+	}
+
+	public setFairlightAudioMixerMasterEqualizerReset(
+		props: Partial<Commands.FairlightMixerMasterEqualizerResetCommand['properties']>
+	): T {
+		const command = new Commands.FairlightMixerMasterEqualizerResetCommand()
+		command.updateProps(props)
+		return this.sendCommand(command)
+	}
+
+	public setFairlightAudioMixerMasterDynamicsReset(props: Partial<FairlightDynamicsResetProps>): T {
+		const command = new Commands.FairlightMixerMasterDynamicsResetCommand()
+		command.updateProps(props)
+		return this.sendCommand(command)
+	}
+
+	public setFairlightAudioMixerResetPeaks(props: Commands.FairlightMixerResetPeakLevelsCommand['properties']): T {
+		const command = new Commands.FairlightMixerResetPeakLevelsCommand(props)
+		return this.sendCommand(command)
+	}
+
+	public startFairlightMixerSendLevels(): T {
+		const command = new Commands.FairlightMixerSendLevelsCommand(true)
+		return this.sendCommand(command)
+	}
+
+	public stopFairlightMixerSendLevels(): T {
+		const command = new Commands.FairlightMixerSendLevelsCommand(false)
+		return this.sendCommand(command)
+	}
+
+	public setFairlightAudioMixerMonitorProps(props: Partial<OmitReadonly<FairlightAudioMonitorChannel>>): T {
+		const command = new Commands.FairlightMixerMonitorCommand()
+		command.updateProps(props)
+		return this.sendCommand(command)
+	}
+
+	public setFairlightAudioMixerMonitorSolo(props: Partial<OmitReadonly<FairlightAudioMonitorSolo>>): T {
+		const command = new Commands.FairlightMixerMonitorSoloCommand()
+		command.updateProps(props)
+		return this.sendCommand(command)
+	}
+
+	public setFairlightAudioMixerInputProps(
+		index: number,
+		props: Commands.FairlightMixerInputCommand['properties']
+	): T {
+		if (this.apiVersion && this.apiVersion >= Enums.ProtocolVersion.V8_0) {
+			const command = new Commands.FairlightMixerInputV8Command(index)
+			command.updateProps(props)
+			return this.sendCommand(command)
+		} else {
+			const command = new Commands.FairlightMixerInputCommand(index)
+			command.updateProps(props)
+			return this.sendCommand(command)
+		}
+	}
+
+	public setFairlightAudioMixerSourceProps(
+		index: number,
+		source: string,
+		props: Commands.FairlightMixerSourceCommand['properties']
+	): T {
+		const command = new Commands.FairlightMixerSourceCommand(index, BigInt(source))
+		command.updateProps(props)
+		return this.sendCommand(command)
+	}
+
+	public setFairlightAudioMixerSourceCompressorProps(
+		index: number,
+		source: string,
+		props: Partial<OmitReadonly<FairlightAudioCompressorState>>
+	): T {
+		const command = new Commands.FairlightMixerSourceCompressorCommand(index, BigInt(source))
+		command.updateProps(props)
+		return this.sendCommand(command)
+	}
+
+	public setFairlightAudioMixerSourceLimiterProps(
+		index: number,
+		source: string,
+		props: Partial<OmitReadonly<FairlightAudioLimiterState>>
+	): T {
+		const command = new Commands.FairlightMixerSourceLimiterCommand(index, BigInt(source))
+		command.updateProps(props)
+		return this.sendCommand(command)
+	}
+
+	public setFairlightAudioMixerSourceExpanderProps(
+		index: number,
+		source: string,
+		props: Partial<OmitReadonly<FairlightAudioExpanderState>>
+	): T {
+		const command = new Commands.FairlightMixerSourceExpanderCommand(index, BigInt(source))
+		command.updateProps(props)
+		return this.sendCommand(command)
+	}
+
+	public setFairlightAudioMixerSourceEqualizerBandProps(
+		index: number,
+		source: string,
+		band: number,
+		props: Partial<OmitReadonly<FairlightAudioEqualizerBandState>>
+	): T {
+		const command = new Commands.FairlightMixerSourceEqualizerBandCommand(index, BigInt(source), band)
+		command.updateProps(props)
+		return this.sendCommand(command)
+	}
+
+	public setFairlightAudioMixerSourceDynamicsReset(
+		index: number,
+		source: string,
+		props: Partial<FairlightDynamicsResetProps>
+	): T {
+		const command = new Commands.FairlightMixerSourceDynamicsResetCommand(index, BigInt(source))
+		command.updateProps(props)
+		return this.sendCommand(command)
+	}
+
+	public setFairlightAudioMixerSourceEqualizerReset(
+		index: number,
+		source: string,
+		props: Partial<Commands.FairlightMixerSourceEqualizerResetCommand['properties']>
+	): T {
+		const command = new Commands.FairlightMixerSourceEqualizerResetCommand(index, BigInt(source))
+		command.updateProps(props)
+		return this.sendCommand(command)
+	}
+
+	public setFairlightAudioMixerSourceResetPeaks(
+		index: number,
+		source: string,
+		props: Commands.FairlightMixerSourceResetPeakLevelsCommand['properties']
+	): T {
+		const command = new Commands.FairlightMixerSourceResetPeakLevelsCommand(index, BigInt(source), props)
+		return this.sendCommand(command)
+	}
+
+	public startStreaming(): T {
+		const command = new Commands.StreamingStatusCommand(true)
+		return this.sendCommand(command)
+	}
+
+	public stopStreaming(): T {
+		const command = new Commands.StreamingStatusCommand(false)
+		return this.sendCommand(command)
+	}
+
+	public requestStreamingDuration(): T {
+		const command = new Commands.StreamingRequestDurationCommand()
+		return this.sendCommand(command)
+	}
+
+	public setStreamingService(props: Partial<StreamingServiceProperties>): T {
+		const command = new Commands.StreamingServiceCommand()
+		command.updateProps(props)
+		return this.sendCommand(command)
+	}
+
+	public setStreamingAudioBitrates(lowBitrate: number, highBitrate: number): T {
+		const command = new Commands.StreamingAudioBitratesCommand(lowBitrate, highBitrate)
+		return this.sendCommand(command)
+	}
+
+	public startRecording(): T {
+		const command = new Commands.RecordingStatusCommand(true)
+		return this.sendCommand(command)
+	}
+
+	public stopRecording(): T {
+		const command = new Commands.RecordingStatusCommand(false)
+		return this.sendCommand(command)
+	}
+
+	public requestRecordingDuration(): T {
+		const command = new Commands.RecordingRequestDurationCommand()
+		return this.sendCommand(command)
+	}
+
+	public switchRecordingDisk(): T {
+		const command = new Commands.RecordingRequestSwitchDiskCommand()
+		return this.sendCommand(command)
+	}
+
+	public setRecordingSettings(props: Partial<RecordingStateProperties>): T {
+		const command = new Commands.RecordingSettingsCommand()
+		command.updateProps(props)
+		return this.sendCommand(command)
+	}
+
+	public setEnableISORecording(enabled: boolean): T {
+		const command = new Commands.RecordingISOCommand(enabled)
+		return this.sendCommand(command)
+	}
+
+	public saveStartupState(): T {
+		const command = new Commands.StartupStateSaveCommand()
+		return this.sendCommand(command)
+	}
+	public clearStartupState(): T {
+		const command = new Commands.StartupStateClearCommand()
+		return this.sendCommand(command)
+	}
+
+	public setMediaPoolSettings(props: Commands.MediaPoolProps): T {
+		const command = new Commands.MediaPoolSettingsSetCommand(props.maxFrames)
+		return this.sendCommand(command)
+	}
+
+	public requestDisplayClockTime(): T {
+		const command = new Commands.DisplayClockRequestTimeCommand()
+		return this.sendCommand(command)
+	}
+
+	public setDisplayClockState(state: Enums.DisplayClockClockState): T {
+		const command = new Commands.DisplayClockStateSetCommand(state)
+		return this.sendCommand(command)
+	}
+
+	public setDisplayClockProperties(props: Partial<Commands.DisplayClockPropertiesExt>): T {
+		const command = new Commands.DisplayClockPropertiesSetCommand()
+		command.updateProps(props)
+		return this.sendCommand(command)
+	}
+
+	public setFairlightAudioRoutingSourceProperties(
+		sourceId: number,
+		props: Partial<OmitReadonly<FairlightAudioRoutingSource>>
+	): T {
+		const command = new Commands.AudioRoutingSourceCommand(sourceId)
+		command.updateProps(props)
+		return this.sendCommand(command)
+	}
+
+	public setFairlightAudioRoutingOutputProperties(
+		sourceId: number,
+		props: Partial<OmitReadonly<FairlightAudioRoutingOutput>>
+	): T {
+		const command = new Commands.AudioRoutingOutputCommand(sourceId)
+		command.updateProps(props)
+		return this.sendCommand(command)
+	}
+}

--- a/src/lib/batchCommands.ts
+++ b/src/lib/batchCommands.ts
@@ -1,0 +1,35 @@
+import type { IBasicAtem } from '../atem'
+import type { ProtocolVersion } from '../enums'
+import type { ISerializableCommand } from '../commands'
+import { AtemCommandSender } from './atemCommands'
+
+/**
+ * A simple command batcher for the ATEM.
+ * This class allows you to queue commands and send them all at once.
+ */
+export class AtemCommandBatch extends AtemCommandSender<void> {
+	readonly #client: IBasicAtem
+
+	#queuedCommands: ISerializableCommand[] = []
+
+	protected get apiVersion(): ProtocolVersion | undefined {
+		return this.#client.state?.info?.apiVersion
+	}
+
+	constructor(client: IBasicAtem) {
+		super()
+
+		this.#client = client
+	}
+
+	async sendQueued(): Promise<void> {
+		const commands = this.#queuedCommands
+		this.#queuedCommands = []
+
+		return this.#client.sendCommands(commands)
+	}
+
+	protected sendCommand(command: ISerializableCommand): void {
+		this.#queuedCommands.push(command)
+	}
+}


### PR DESCRIPTION

## About the Contributor
This pull request is posted on behalf of myself


## Type of Contribution

This is a: Feature 

## Current Behavior

Since #157, it has been possible to send commands in batches. This can be necessary when sending many commands to both avoid retransmits, and to minimise the visual staggering of the changes.  
157 solved this for the method of manual construction of the command classes, by allowing multiple to be provided to the sender at once which would then group them and send them in fewer packets.

This works, but leaves out the simpler api of the library.

## New Behavior

This adds a new and user friendly way to batch the sending of commands.

The approach I have taken is to pull out the command methods into their own class which can be used in multiple class implementations, to minimise the effort going forward.

This can be used by doing:
```

const atem = new Atem() // or new BasicAtem(). Whatever you usually do.

const batcher = new AtemCommandBatch(atem)

batcher.changeProgramInput(2, 0)
batcher.changeProgramInput(4, 1)

// Send batch and empty queue
batcher.sendQueued().then(() => {
  console.log('commands sent')
})


// Start a new batch
batcher.changePreviewInput(7, 0)
batcher.changePreviewInput(7, 1)

// Send batch
batcher.sendQueued().then(() => {
  console.log('commands sent')
})

```


## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [ ] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
