### PR TITLE
feat: Run order groups for ATEM commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "postinstall": "./node_modules/.bin/husky install",
-    "prepack": "pinst --disable",
+    "prepack": "pinst --disable && run build:main",
     "postpack": "pinst --enable",
     "build": "rimraf dist && run build:main",
     "build:main": "tsc -p tsconfig.build.json",

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -42,6 +42,7 @@ test('setSuperSourceProperties - 7.2', async () => {
 		expect(conn.sendCommand).toHaveBeenCalledTimes(1)
 		expect(conn.sendCommand).toHaveBeenNthCalledWith(1, {
 			flag: 12,
+			runOrderGroup: 0,
 			_properties: {
 				artOption: 0,
 				artPreMultiplied: true,
@@ -68,6 +69,7 @@ test('setSuperSourceProperties - 8.0', async () => {
 		expect(conn.sendCommand).toHaveBeenNthCalledWith(1, {
 			ssrcId: 2,
 			flag: 12,
+			runOrderGroup: 0,
 			_properties: {
 				artOption: 0,
 				artPreMultiplied: true,
@@ -93,6 +95,7 @@ test('setSuperSourceBorder - 7.2', async () => {
 		expect(conn.sendCommand).toHaveBeenCalledTimes(1)
 		expect(conn.sendCommand).toHaveBeenNthCalledWith(1, {
 			flag: 139264,
+			runOrderGroup: 0,
 			_properties: {
 				borderBevelSoftness: 12,
 				borderLuma: 3,
@@ -119,6 +122,7 @@ test('setSuperSourceBorder - 8.0', async () => {
 		expect(conn.sendCommand).toHaveBeenNthCalledWith(1, {
 			ssrcId: 2,
 			flag: 1088,
+			runOrderGroup: 0,
 			_properties: {
 				borderBevelSoftness: 12,
 				borderLuma: 3,

--- a/src/commands/CommandBase.ts
+++ b/src/commands/CommandBase.ts
@@ -23,12 +23,15 @@ export abstract class DeserializedCommand<T> implements IDeserializedCommand {
 
 export interface ISerializableCommand {
 	serialize(version: ProtocolVersion): Buffer
+	runOrderGroup?: number
 }
 
 /** Base command type for a simple writable command, which has a few values which must all be sent */
 export abstract class BasicWritableCommand<T> implements ISerializableCommand {
 	public static readonly rawName?: string
 	public static readonly minimumVersion?: ProtocolVersion
+
+	public runOrderGroup?: number = 0
 
 	protected _properties: T
 

--- a/src/commands/CommandBase.ts
+++ b/src/commands/CommandBase.ts
@@ -23,6 +23,14 @@ export abstract class DeserializedCommand<T> implements IDeserializedCommand {
 
 export interface ISerializableCommand {
 	serialize(version: ProtocolVersion): Buffer
+	/**
+	 * Controls the command's execution order and batching.
+	 *
+	 * Lower values run **earlier**. Commands with different `runOrderGroup` values
+	 * will not be processed in the same batch.
+	 *
+	 * Defaults to 0. Use a **negative value** to ensure execution before the default group.
+	 */
 	runOrderGroup?: number
 }
 
@@ -31,6 +39,7 @@ export abstract class BasicWritableCommand<T> implements ISerializableCommand {
 	public static readonly rawName?: string
 	public static readonly minimumVersion?: ProtocolVersion
 
+	/** @link ISerializableCommand.runOrderGroup */
 	public runOrderGroup?: number = 0
 
 	protected _properties: T


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core//docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This pull request is posted on behalf of the BBC.

## Type of Contribution

This is a Feature

It's required for the following bugfix: https://github.com/Sofie-Automation/sofie-atem-state/pull/37.

## Current Behavior

Commands sent to an ATEM are batched where possible. You cannot control which batch they go in. Additionally the ATEM firmware sometimes seems to execute things out of order within a batch.. On some occasions, order is important, for example when setting up and switching on a key it's important not to switch it on until after it's input are all set. Also when switching it off, it's important not to make any other changes until after it has switched off. 

## New Behavior

You can set a runOrderGroup property on an ATEM command. This is a number. Commands will only be batched if they are in the same group. Groups will be run in numerical order. Default is 0, so you can use a positive number to run something after other commands (such as turning on a key after sending it's settings), or a negative number to ensure it happens first (such as turning off a key before changing settings).

## Testing Instructions

This will be easiest to test in conjunction with the corresponding PR in ATEM-state.

## Other Information

A minor version bump and release will be needed as this adds new API surface. It is backwards compatible as a default is provided which won't change behaviour.

VSCode was showing syntax problems for me because the build target for typescript was older than some of the library features being used, so I bumped the version to match `@sofie-automation/code-standard-preset`. I didn't upgrade the dependency on that project because that caused other issues which will need addressing.

## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core//)) has been added / updated.
