### PR TITLE
feat: Allow installing direct from git repository (publish.yaml‎ fix)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -81,7 +81,7 @@ jobs:
               echo "Publishing experimental"
               echo "tag=experimental" >> $GITHUB_OUTPUT
             fi
-            
+
             HASH=$(git rev-parse --short HEAD)
             TIMESTAMP=$(date +"%Y%m%d-%H%M%S")
             PRERELEASE_TAG=nightly-$(echo "${{ github.ref_name }}" | sed -r 's/[^a-z0-9]+/-/gi')
@@ -172,8 +172,11 @@ jobs:
           corepack enable
           yarn install
 
+          # Disable postinstall in published release
+          yarn pinst --disable
+
           # Publish from the extracted release (build output present)
-          npm publish --access=public --provenance --tag ${{ needs.prepare.outputs.tag }}
+          npm publish --ignore-scripts --access=public --provenance --tag ${{ needs.prepare.outputs.tag }}
 
           NEW_VERSION=$(node -p "require('./package.json').version")
           echo "**Published:** $NEW_VERSION" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## About the Contributor

This pull request is posted on behalf of SuperFlyTv


## Type of Contribution

This is a code improvement

## Current Behavior

If you try to use a forked version of this project in your package.json, for example by adding:

```json
		"atem-connection": "github:Sofie-Automation/sofie-atem-connection#rjmunro/install-from-git"
```

It would fail because it didn't know it had to build.

## New Behavior

It will build the package after installing from git.

I've modified the npm publish process a bit to 

## Testing Instructions

Create a trivial project in yarn and add this branch as a dependency:

```bash
yarn init
yarn add atem-connection@github:Sofie-Automation/sofie-atem-connection#rjmunro/install-from-git
```

Then check that it works. (TODO: Expand this)

## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [ ] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core//)) has been added / updated.
